### PR TITLE
consolidate types in src/types/

### DIFF
--- a/src/lib/registry_authenticator.ts
+++ b/src/lib/registry_authenticator.ts
@@ -6,16 +6,7 @@ import {
   type RegistryErrorCode,
   RegistryErrorCodes,
 } from "../utils/error_handling.ts";
-import type { RegistryCredentials } from "../types/registry.ts";
-
-/**
- * Authentication result interface
- */
-export interface AuthenticationResult {
-  success: boolean;
-  registry: string;
-  message?: string;
-}
+import type { AuthenticationResult, RegistryCredentials } from "../types.ts";
 
 /**
  * Registry authenticator for handling container engine authentication

--- a/src/lib/registry_service.ts
+++ b/src/lib/registry_service.ts
@@ -5,63 +5,21 @@ import {
   type RegistryConfig,
   RegistryConfigManager,
 } from "../utils/registry_config.ts";
-import {
-  type AuthenticationResult,
-  RegistryAuthenticator,
-} from "./registry_authenticator.ts";
-import type { RegistryCredentials } from "../types/registry.ts";
+import { RegistryAuthenticator } from "./registry_authenticator.ts";
 import type { ContainerEngine } from "./configuration/builder.ts";
 import {
   createRegistryError,
   getErrorMessage,
   RegistryErrorCodes,
 } from "../utils/error_handling.ts";
-
-/**
- * Registry information interface
- */
-export interface RegistryInfo {
-  url: string;
-  type: "local" | "remote";
-  port?: number;
-  username?: string;
-  isDefault: boolean;
-  lastLogin?: string;
-  status: RegistryStatus;
-}
-
-/**
- * Registry status information
- */
-export interface RegistryStatus {
-  available: boolean;
-  authenticated: boolean;
-  running?: boolean; // For local registries
-  containerId?: string; // For local registries
-  message?: string;
-}
-
-/**
- * Registry setup options
- */
-export interface RegistrySetupOptions {
-  type?: "local" | "remote";
-  port?: number;
-  credentials?: RegistryCredentials;
-  isDefault?: boolean;
-  skipAuthentication?: boolean;
-}
-
-/**
- * Registry operation result
- */
-export interface RegistryOperationResult {
-  success: boolean;
-  registry: string;
-  operation: string;
-  message?: string;
-  data?: Record<string, unknown>;
-}
+import type {
+  AuthenticationResult,
+  RegistryCredentials,
+  RegistryInfo,
+  RegistryOperationResult,
+  RegistrySetupOptions,
+  RegistryStatus,
+} from "../types.ts";
 
 /**
  * Main registry service that encapsulates all registry operations

--- a/src/lib/services/build_service.ts
+++ b/src/lib/services/build_service.ts
@@ -1,33 +1,8 @@
-import type { ContainerEngine } from "../configuration/builder.ts";
-import type { RegistryConfiguration } from "../configuration/registry.ts";
 import type { ServiceConfiguration } from "../configuration/service.ts";
-import type { GlobalOptions } from "../../types.ts";
 import { ImagePushService } from "./image_push_service.ts";
 import { RegistryAuthService } from "./registry_auth_service.ts";
 import { log } from "../../utils/logger.ts";
-
-/**
- * Options for BuildService
- */
-export interface BuildServiceOptions {
-  engine: ContainerEngine;
-  registry: RegistryConfiguration;
-  globalOptions: GlobalOptions;
-  noCache?: boolean;
-  push?: boolean;
-  cacheEnabled?: boolean;
-}
-
-/**
- * Result of building a service
- */
-export interface BuildResult {
-  serviceName: string;
-  success: boolean;
-  imageName: string;
-  latestImageName: string;
-  error?: string;
-}
+import type { BuildResult, BuildServiceOptions } from "../../types.ts";
 
 /**
  * Service for building container images

--- a/src/lib/services/container_deployment_service.ts
+++ b/src/lib/services/container_deployment_service.ts
@@ -29,34 +29,7 @@ import {
   CONTAINER_START_RETRY_DELAY_MS,
   JIJI_NETWORK_NAME,
 } from "../../constants.ts";
-
-/**
- * Options for container deployment
- */
-export interface DeploymentOptions {
-  /**
-   * Custom version tag (defaults to "latest")
-   */
-  version?: string;
-  /**
-   * All SSH managers for cluster-wide operations
-   */
-  allSshManagers?: SSHManager[];
-}
-
-/**
- * Result of container deployment
- */
-export interface DeploymentResult {
-  service: string;
-  host: string;
-  success: boolean;
-  containerName?: string;
-  imageName?: string;
-  containerIp?: string;
-  oldContainerName?: string; // Name of the old container that was renamed (for cleanup after health checks)
-  error?: string;
-}
+import type { DeploymentOptions, DeploymentResult } from "../../types.ts";
 
 /**
  * Service for deploying containers to remote servers

--- a/src/lib/services/deployment_metrics.ts
+++ b/src/lib/services/deployment_metrics.ts
@@ -5,64 +5,12 @@
  */
 
 import { log } from "../../utils/logger.ts";
-import type { DeploymentResult } from "./container_deployment_service.ts";
-import type { ProxyConfigResult, ProxyInstallResult } from "./proxy_service.ts";
-
-/**
- * Deployment metrics data
- */
-export interface DeploymentMetrics {
-  deploymentId: string;
-  timestamp: Date;
-  projectName: string;
-  version?: string;
-
-  // Timing metrics
-  startTime: Date;
-  endTime?: Date;
-  totalDurationMs?: number;
-
-  // Service metrics
-  totalServices: number;
-  successfulDeployments: number;
-  failedDeployments: number;
-  rolledBackDeployments: number;
-
-  // Proxy metrics
-  proxyHostsConfigured: number;
-  proxyServicesConfigured: number;
-  proxyInstallFailures: number;
-  proxyConfigFailures: number;
-
-  // Health check metrics
-  healthChecksPassed: number;
-  healthChecksFailed: number;
-  avgHealthCheckDurationMs?: number;
-
-  // Rollback metrics
-  rollbacksTriggered: number;
-  rollbacksSuccessful: number;
-  rollbacksFailed: number;
-
-  // Error tracking
-  errors: Array<{
-    type: "deployment" | "proxy" | "health_check" | "rollback" | "other";
-    service?: string;
-    host?: string;
-    message: string;
-    timestamp: Date;
-  }>;
-
-  // Performance metrics
-  deploymentSteps: Array<{
-    step: string;
-    startTime: Date;
-    endTime?: Date;
-    durationMs?: number;
-    success: boolean;
-    error?: string;
-  }>;
-}
+import type {
+  DeploymentMetrics,
+  DeploymentResult,
+  ProxyConfigResult,
+  ProxyInstallResult,
+} from "../../types.ts";
 
 /**
  * Deployment step timing helper

--- a/src/lib/services/deployment_orchestrator.ts
+++ b/src/lib/services/deployment_orchestrator.ts
@@ -12,36 +12,17 @@
 import type { Configuration } from "../configuration.ts";
 import type { ServiceConfiguration } from "../configuration/service.ts";
 import type { SSHManager } from "../../utils/ssh.ts";
-import {
-  ContainerDeploymentService,
-  type DeploymentResult,
-} from "./container_deployment_service.ts";
-import {
-  type ProxyConfigResult,
-  type ProxyInstallResult,
-  ProxyService,
-} from "./proxy_service.ts";
-import {
-  type DeploymentMetrics,
-  deploymentMetrics,
-} from "./deployment_metrics.ts";
+import { ContainerDeploymentService } from "./container_deployment_service.ts";
+import { ProxyService } from "./proxy_service.ts";
+import { deploymentMetrics } from "./deployment_metrics.ts";
 import { log } from "../../utils/logger.ts";
-
-export interface OrchestrationOptions {
-  version?: string;
-  allSshManagers?: SSHManager[];
-}
-
-export interface OrchestrationResult {
-  success: boolean;
-  proxyInstallResults: ProxyInstallResult[];
-  deploymentResults: DeploymentResult[];
-  proxyConfigResults: ProxyConfigResult[];
-  errors: string[];
-  warnings: string[];
-  deploymentId?: string;
-  metrics?: DeploymentMetrics;
-}
+import type {
+  DeploymentResult,
+  OrchestrationOptions,
+  OrchestrationResult,
+  ProxyConfigResult,
+  ProxyInstallResult,
+} from "../../types.ts";
 
 /**
  * Orchestrates the complete deployment workflow

--- a/src/lib/services/image_prune_service.ts
+++ b/src/lib/services/image_prune_service.ts
@@ -6,31 +6,7 @@ import type { ContainerEngine } from "../configuration/builder.ts";
 import type { SSHManager } from "../../utils/ssh.ts";
 import { log } from "../../utils/logger.ts";
 import { executeBestEffort } from "../../utils/command_helpers.ts";
-
-/**
- * Options for image pruning
- */
-export interface PruneOptions {
-  /**
-   * Number of recent images to retain per service (default: 3)
-   */
-  retain?: number;
-  /**
-   * Whether to remove dangling images (default: true)
-   */
-  removeDangling?: boolean;
-}
-
-/**
- * Result of image pruning operation
- */
-export interface PruneResult {
-  host: string;
-  success: boolean;
-  imagesRemoved: number;
-  spaceSaved?: string;
-  error?: string;
-}
+import type { PruneOptions, PruneResult } from "../../types.ts";
 
 /**
  * Service for managing Docker/Podman image retention

--- a/src/lib/services/image_push_service.ts
+++ b/src/lib/services/image_push_service.ts
@@ -1,25 +1,5 @@
-import type { ContainerEngine } from "../configuration/builder.ts";
-import type { RegistryConfiguration } from "../configuration/registry.ts";
 import { log } from "../../utils/logger.ts";
-import type { GlobalOptions } from "../../types.ts";
-
-/**
- * Options for image push operations
- */
-export interface PushOptions {
-  engine: ContainerEngine;
-  registry: RegistryConfiguration;
-  globalOptions: GlobalOptions;
-}
-
-/**
- * Result of a push operation
- */
-export interface PushResult {
-  imageName: string;
-  success: boolean;
-  error?: Error;
-}
+import type { PushOptions, PushResult } from "../../types.ts";
 
 /**
  * Service for pushing container images to registries

--- a/src/lib/services/proxy_service.ts
+++ b/src/lib/services/proxy_service.ts
@@ -11,28 +11,7 @@ import { createServerAuditLogger } from "../../utils/audit.ts";
 import { getDnsServerForHost } from "../../utils/network_helpers.ts";
 import { getContainerIp } from "./container_registry.ts";
 import { log } from "../../utils/logger.ts";
-
-/**
- * Result of proxy installation on a host
- */
-export interface ProxyInstallResult {
-  host: string;
-  success: boolean;
-  message?: string;
-  error?: string;
-  version?: string;
-}
-
-/**
- * Result of proxy service configuration
- */
-export interface ProxyConfigResult {
-  service: string;
-  host: string;
-  success: boolean;
-  message?: string;
-  error?: string;
-}
+import type { ProxyConfigResult, ProxyInstallResult } from "../../types.ts";
 
 /**
  * Service for managing kamal-proxy across multiple hosts

--- a/src/lib/services/registry_auth_service.ts
+++ b/src/lib/services/registry_auth_service.ts
@@ -7,15 +7,7 @@ import type { RegistryConfiguration } from "../configuration/registry.ts";
 import type { SSHManager } from "../../utils/ssh.ts";
 import { RegistryAuthenticator } from "../registry_authenticator.ts";
 import { log } from "../../utils/logger.ts";
-
-/**
- * Result of remote registry authentication
- */
-export interface RemoteAuthResult {
-  host: string;
-  success: boolean;
-  error?: string;
-}
+import type { RemoteAuthResult } from "../../types.ts";
 
 /**
  * Service for handling registry authentication across local and remote hosts

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,10 @@
-export interface AuditEntry {
-  timestamp: string;
-  action: string;
-  details?: Record<string, unknown>;
-  user?: string;
-  host?: string;
-  status: "started" | "success" | "failed" | "warning";
-  message?: string;
-}
+/**
+ * Central type definitions and re-exports for the Jiji application
+ */
+
+// ============================================================================
+// Global Options and Command Types
+// ============================================================================
 
 export interface GlobalOptions {
   environment?: string;
@@ -17,7 +15,10 @@ export interface GlobalOptions {
   services?: string;
 }
 
-// Configuration system types
+// ============================================================================
+// Configuration System Types
+// ============================================================================
+
 export interface ValidationError {
   path: string;
   message: string;
@@ -42,7 +43,7 @@ export interface ConfigurationContext {
   [key: string]: unknown;
 }
 
-// Re-export types from configuration system
+// Re-export configuration types
 export type { ContainerEngine } from "./lib/configuration.ts";
 export type { Configuration } from "./lib/configuration.ts";
 export type { ServiceConfiguration } from "./lib/configuration.ts";
@@ -50,23 +51,125 @@ export type { SSHConfiguration } from "./lib/configuration.ts";
 export type { EnvironmentConfiguration } from "./lib/configuration.ts";
 export { ConfigurationError } from "./lib/configuration.ts";
 
-// Re-export registry types
+// ============================================================================
+// Common Utility Types
+// ============================================================================
+
+export type {
+  AggregatedResults,
+  CommandContext,
+  CommandContextOptions,
+  CommandHandler,
+  ConfigLoadResult,
+  EngineInstallResult,
+  ErrorHandlerContext,
+  GitFileStatus,
+  KamalProxyDeployOptions,
+  LoggerOptions,
+  LogLevel,
+  OperationResult,
+  ParsedMount,
+  ServiceFilterOptions,
+  ServiceGroupingOptions,
+  VersionOptions,
+} from "./types/common.ts";
+
+// ============================================================================
+// SSH and Remote Execution Types
+// ============================================================================
+
+export type { CommandResult, SSHConnectionConfig } from "./types/ssh.ts";
+
+export { SSH_ALGORITHMS } from "./types/ssh.ts";
+
+// ============================================================================
+// Audit and Logging Types
+// ============================================================================
+
+export type {
+  AuditEntry,
+  LockInfo,
+  LockManager,
+  RemoteAuditResult,
+} from "./types/audit.ts";
+
+// ============================================================================
+// Deployment Types
+// ============================================================================
+
+export type {
+  BuildResult,
+  BuildServiceOptions,
+  DeploymentMetrics,
+  DeploymentOptions,
+  DeploymentResult,
+  OrchestrationOptions,
+  OrchestrationResult,
+  ProxyConfigResult,
+  ProxyInstallResult,
+  PruneOptions,
+  PruneResult,
+  PushOptions,
+  PushResult,
+  RemoteAuthResult,
+} from "./types/deployment.ts";
+
+// ============================================================================
+// Registry Types
+// ============================================================================
+
 export type {
   AuthenticationResult,
+  LocalRegistryContainer,
+  RegistryBackupInfo,
   RegistryCommandOptions,
+  RegistryConfig,
   RegistryCredentials,
+  RegistryEnvironment,
+  RegistryEvent,
+  RegistryEventType,
   RegistryHealthCheck,
+  RegistryImageInfo,
   RegistryInfo,
   RegistryListOptions,
+  RegistryMetrics,
+  RegistryMigrationOptions,
   RegistryOperation,
   RegistryOperationResult,
+  RegistrySearchResult,
+  RegistryServiceConfig,
   RegistrySetupOptions,
   RegistryStatus,
   RegistryType,
+  RegistryUrlComponents,
   RegistryValidationResult,
+  RegistryValidationRules,
 } from "./types/registry.ts";
 
-// Re-export error handling types
+// ============================================================================
+// Network Types
+// ============================================================================
+
+export type {
+  ContainerRegistration,
+  CorrosionConfig,
+  DNSConfig,
+  NetworkDependencies,
+  NetworkDiscovery,
+  NetworkServer,
+  NetworkSetupResult,
+  NetworkStatus,
+  NetworkTopology,
+  ServerRegistration,
+  ServiceRegistration,
+  WireGuardConfig,
+  WireGuardPeer,
+} from "./types/network.ts";
+
+// ============================================================================
+// Error Handling Types
+// ============================================================================
+
 export {
   RegistryError,
   type RegistryErrorCode,

--- a/src/types/audit.ts
+++ b/src/types/audit.ts
@@ -1,0 +1,48 @@
+/**
+ * Audit and logging type definitions
+ */
+
+/**
+ * Audit entry stored in remote audit logs
+ */
+export interface AuditEntry {
+  timestamp: string;
+  action: string;
+  details?: Record<string, unknown>;
+  user?: string;
+  host?: string;
+  status: "started" | "success" | "failed" | "warning";
+  message?: string;
+}
+
+/**
+ * Result of remote audit operation
+ */
+export interface RemoteAuditResult {
+  host: string;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Lock information for deployment coordination
+ */
+export interface LockInfo {
+  locked: boolean;
+  message?: string;
+  acquiredAt?: string;
+  acquiredBy?: string;
+  host?: string;
+  pid?: number;
+  version?: string;
+}
+
+/**
+ * Lock manager interface for managing deployment locks
+ */
+export interface LockManager {
+  acquire(message: string): Promise<boolean>;
+  release(): Promise<boolean>;
+  status(): Promise<LockInfo>;
+  isLocked(): Promise<boolean>;
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,159 @@
+/**
+ * Common utility types used across the application
+ */
+
+/**
+ * Log levels for structured logging
+ */
+export type LogLevel =
+  | "debug"
+  | "info"
+  | "warn"
+  | "error"
+  | "fatal"
+  | "success"
+  | "trace";
+
+/**
+ * Logger configuration options
+ */
+export interface LoggerOptions {
+  prefix?: string;
+  showTimestamp?: boolean;
+  maxPrefixLength?: number;
+  colors?: boolean;
+  minLevel?: LogLevel;
+}
+
+/**
+ * Result of an operation that can succeed or fail
+ */
+export interface OperationResult<T> {
+  success: boolean;
+  result?: T;
+  error?: Error;
+  host?: string;
+}
+
+/**
+ * Aggregated results containing both successes and failures
+ */
+export interface AggregatedResults<T> {
+  results: T[];
+  errors: Error[];
+  successCount: number;
+  errorCount: number;
+  totalCount: number;
+}
+
+/**
+ * Configuration loading result
+ */
+export interface ConfigLoadResult {
+  success: boolean;
+  error?: string;
+  warnings?: string[];
+}
+
+/**
+ * Container engine installation result
+ */
+export interface EngineInstallResult {
+  installed: boolean;
+  version?: string;
+  error?: string;
+}
+
+/**
+ * Error handler context for centralized error handling
+ */
+export interface ErrorHandlerContext {
+  operation: string;
+  host?: string;
+  service?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Command execution context options
+ */
+export interface CommandContextOptions {
+  verbose?: boolean;
+  environment?: string;
+  configFile?: string;
+  version?: string;
+  hosts?: string;
+  services?: string;
+}
+
+/**
+ * Command execution context
+ */
+export interface CommandContext {
+  options: CommandContextOptions;
+  args: string[];
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Generic command handler function type
+ */
+export type CommandHandler<T = void> = (
+  context: CommandContext,
+) => Promise<T> | T;
+
+/**
+ * Version management options
+ */
+export interface VersionOptions {
+  version?: string;
+  force?: boolean;
+}
+
+/**
+ * Git file status information
+ */
+export interface GitFileStatus {
+  path: string;
+  status: string;
+  staged: boolean;
+}
+
+/**
+ * Parsed mount specification
+ */
+export interface ParsedMount {
+  source: string;
+  target: string;
+  type?: "volume" | "bind" | "tmpfs";
+  options?: string[];
+  readonly?: boolean;
+}
+
+/**
+ * Service filtering options
+ */
+export interface ServiceFilterOptions {
+  services?: string;
+  hosts?: string;
+  includeAll?: boolean;
+}
+
+/**
+ * Service grouping options for deployment
+ */
+export interface ServiceGroupingOptions {
+  groupBy?: "service" | "host";
+  parallel?: boolean;
+  maxConcurrency?: number;
+}
+
+/**
+ * Kamal proxy deployment options
+ */
+export interface KamalProxyDeployOptions {
+  version?: string;
+  port?: number;
+  network?: string;
+  logLevel?: string;
+}

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -1,0 +1,224 @@
+/**
+ * Deployment and service-related type definitions
+ */
+
+import type { ContainerEngine } from "../lib/configuration/builder.ts";
+import type { RegistryConfiguration } from "../lib/configuration/registry.ts";
+import type { SSHManager } from "../utils/ssh.ts";
+
+/**
+ * Build service options
+ */
+export interface BuildServiceOptions {
+  engine: ContainerEngine;
+  registry: RegistryConfiguration;
+  globalOptions: {
+    environment?: string;
+    verbose?: boolean;
+    version?: string;
+    configFile?: string;
+    hosts?: string;
+    services?: string;
+  };
+  noCache?: boolean;
+  push?: boolean;
+  cacheEnabled?: boolean;
+}
+
+/**
+ * Build result
+ */
+export interface BuildResult {
+  serviceName: string;
+  success: boolean;
+  imageName: string;
+  latestImageName: string;
+  error?: string;
+}
+
+/**
+ * Deployment options for container deployment
+ */
+export interface DeploymentOptions {
+  /**
+   * Custom version tag (defaults to "latest")
+   */
+  version?: string;
+  /**
+   * All SSH managers for cluster-wide operations
+   */
+  allSshManagers?: SSHManager[];
+}
+
+/**
+ * Container deployment result
+ */
+export interface DeploymentResult {
+  service: string;
+  host: string;
+  success: boolean;
+  containerName?: string;
+  imageName?: string;
+  containerIp?: string;
+  oldContainerName?: string; // Name of the old container that was renamed (for cleanup after health checks)
+  error?: string;
+}
+
+/**
+ * Deployment metrics data
+ */
+export interface DeploymentMetrics {
+  deploymentId: string;
+  timestamp: Date;
+  projectName: string;
+  version?: string;
+
+  // Timing metrics
+  startTime: Date;
+  endTime?: Date;
+  totalDurationMs?: number;
+
+  // Service metrics
+  totalServices: number;
+  successfulDeployments: number;
+  failedDeployments: number;
+  rolledBackDeployments: number;
+
+  // Proxy metrics
+  proxyHostsConfigured: number;
+  proxyServicesConfigured: number;
+  proxyInstallFailures: number;
+  proxyConfigFailures: number;
+
+  // Health check metrics
+  healthChecksPassed: number;
+  healthChecksFailed: number;
+  avgHealthCheckDurationMs?: number;
+
+  // Rollback metrics
+  rollbacksTriggered: number;
+  rollbacksSuccessful: number;
+  rollbacksFailed: number;
+
+  // Error tracking
+  errors: Array<{
+    type: "deployment" | "proxy" | "health_check" | "rollback" | "other";
+    service?: string;
+    host?: string;
+    message: string;
+    timestamp: Date;
+  }>;
+
+  // Performance metrics
+  deploymentSteps: Array<{
+    step: string;
+    startTime: Date;
+    endTime?: Date;
+    durationMs?: number;
+    success: boolean;
+    error?: string;
+  }>;
+}
+
+/**
+ * Orchestration options for multi-service deployment
+ */
+export interface OrchestrationOptions {
+  version?: string;
+  allSshManagers?: SSHManager[];
+}
+
+/**
+ * Orchestration result
+ */
+export interface OrchestrationResult {
+  success: boolean;
+  proxyInstallResults: ProxyInstallResult[];
+  deploymentResults: DeploymentResult[];
+  proxyConfigResults: ProxyConfigResult[];
+  errors: string[];
+  warnings: string[];
+  deploymentId?: string;
+  metrics?: DeploymentMetrics;
+}
+
+/**
+ * Image prune options
+ */
+export interface PruneOptions {
+  /**
+   * Number of recent images to retain per service (default: 3)
+   */
+  retain?: number;
+  /**
+   * Whether to remove dangling images (default: true)
+   */
+  removeDangling?: boolean;
+}
+
+/**
+ * Image prune result
+ */
+export interface PruneResult {
+  host: string;
+  success: boolean;
+  imagesRemoved: number;
+  spaceSaved?: string;
+  error?: string;
+}
+
+/**
+ * Image push options
+ */
+export interface PushOptions {
+  engine: ContainerEngine;
+  registry: RegistryConfiguration;
+  globalOptions: {
+    environment?: string;
+    verbose?: boolean;
+    version?: string;
+    configFile?: string;
+    hosts?: string;
+    services?: string;
+  };
+}
+
+/**
+ * Image push result
+ */
+export interface PushResult {
+  imageName: string;
+  success: boolean;
+  error?: Error;
+}
+
+/**
+ * Proxy installation result
+ */
+export interface ProxyInstallResult {
+  host: string;
+  success: boolean;
+  message?: string;
+  error?: string;
+  version?: string;
+}
+
+/**
+ * Proxy configuration result
+ */
+export interface ProxyConfigResult {
+  service: string;
+  host: string;
+  success: boolean;
+  message?: string;
+  error?: string;
+}
+
+/**
+ * Remote registry authentication result
+ */
+export interface RemoteAuthResult {
+  host: string;
+  success: boolean;
+  error?: string;
+}

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -14,8 +14,11 @@ export type RegistryOperation =
   | "login"
   | "logout"
   | "setup"
+  | "setup-local"
+  | "setup-remote"
   | "list"
   | "use"
+  | "set-default"
   | "status"
   | "authenticate";
 

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -1,0 +1,67 @@
+import type { LogLevel } from "./common.ts";
+
+/**
+ * SSH-related type definitions
+ */
+
+/**
+ * Default SSH algorithms for compatibility with various SSH servers
+ */
+export const SSH_ALGORITHMS = {
+  serverHostKey: [
+    "ssh-rsa",
+    "ecdsa-sha2-nistp256",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp521",
+    "ssh-ed25519",
+  ],
+  kex: [
+    "ecdh-sha2-nistp256",
+    "ecdh-sha2-nistp384",
+    "ecdh-sha2-nistp521",
+    "diffie-hellman-group14-sha256",
+    "diffie-hellman-group16-sha512",
+    "diffie-hellman-group1-sha1",
+  ],
+  cipher: [
+    "aes128-ctr",
+    "aes256-ctr",
+    "aes128-cbc",
+  ],
+  hmac: [
+    "hmac-sha2-256",
+    "hmac-sha2-512",
+    "hmac-sha1",
+  ],
+  compress: ["none"],
+} as const;
+
+/**
+ * SSH connection configuration
+ */
+export interface SSHConnectionConfig {
+  host: string;
+  username: string;
+  port?: number;
+  useAgent?: boolean;
+  proxy?: string;
+  proxyCommand?: string;
+  keys?: string[];
+  keyData?: string[];
+  keysOnly?: boolean;
+  dnsRetries?: number;
+  sshConfigFiles?: string[] | false;
+  connectTimeout?: number;
+  keyPath?: string;
+  logLevel?: LogLevel;
+}
+
+/**
+ * Result of executing a command via SSH
+ */
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  success: boolean;
+  code: number | null;
+}

--- a/src/utils/audit.ts
+++ b/src/utils/audit.ts
@@ -2,13 +2,7 @@ import { join } from "@std/path";
 import type { SSHManager } from "./ssh.ts";
 import { executeHostOperations } from "./promise_helpers.ts";
 import { log, Logger } from "./logger.ts";
-import type { AuditEntry } from "../types.ts";
-
-export interface RemoteAuditResult {
-  host: string;
-  success: boolean;
-  error?: string;
-}
+import type { AuditEntry, RemoteAuditResult } from "../types.ts";
 
 export class RemoteAuditLogger {
   private sshManager: SSHManager;

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -1,23 +1,7 @@
 import { join } from "@std/path";
 import type { SSHManager } from "./ssh.ts";
 import { executeHostOperations } from "./promise_helpers.ts";
-
-export interface LockInfo {
-  locked: boolean;
-  message?: string;
-  acquiredAt?: string;
-  acquiredBy?: string;
-  host?: string;
-  pid?: number;
-  version?: string;
-}
-
-export interface LockManager {
-  acquire(message: string): Promise<boolean>;
-  release(): Promise<boolean>;
-  status(): Promise<LockInfo>;
-  isLocked(): Promise<boolean>;
-}
+import type { LockInfo, LockManager } from "../types.ts";
 
 /**
  * Remote lock manager for SSH-based deployments

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,21 +1,5 @@
 import { colors } from "@cliffy/ansi/colors";
-
-export interface LoggerOptions {
-  prefix?: string;
-  showTimestamp?: boolean;
-  maxPrefixLength?: number;
-  colors?: boolean;
-  minLevel?: LogLevel;
-}
-
-export type LogLevel =
-  | "debug"
-  | "info"
-  | "warn"
-  | "error"
-  | "fatal"
-  | "success"
-  | "trace";
+import type { LoggerOptions, LogLevel } from "../types.ts";
 
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
   fatal: 0,

--- a/src/utils/promise_helpers.ts
+++ b/src/utils/promise_helpers.ts
@@ -1,4 +1,5 @@
 import { log } from "./logger.ts";
+import type { AggregatedResults } from "../types.ts";
 
 /**
  * Enhanced promise utilities for better error handling in multi-host operations
@@ -6,27 +7,6 @@ import { log } from "./logger.ts";
  * These utilities provide patterns that wait for all operations to complete
  * and collect comprehensive error information instead of failing fast.
  */
-
-/**
- * Result of an operation that can succeed or fail
- */
-export interface OperationResult<T> {
-  success: boolean;
-  result?: T;
-  error?: Error;
-  host?: string;
-}
-
-/**
- * Aggregated results containing both successes and failures
- */
-export interface AggregatedResults<T> {
-  results: T[];
-  errors: Error[];
-  successCount: number;
-  errorCount: number;
-  totalCount: number;
-}
 
 /**
  * Execute operations with comprehensive error collection

--- a/src/utils/ssh.ts
+++ b/src/utils/ssh.ts
@@ -2,64 +2,17 @@ import { NodeSSH } from "node-ssh";
 import { Client, type ClientChannel } from "ssh2";
 import { SSHProxy } from "./ssh_proxy.ts";
 import { SSHConfigParser } from "./ssh_config_parser.ts";
-import { Logger, type LogLevel } from "./logger.ts";
+import { Logger } from "./logger.ts";
+import type { LogLevel } from "../types.ts";
+import {
+  type CommandResult,
+  SSH_ALGORITHMS,
+  type SSHConnectionConfig,
+} from "../types.ts";
 
-/**
- * Default SSH algorithms for compatibility with various SSH servers
- * These can be customized if needed for specific server configurations
- */
-export const SSH_ALGORITHMS = {
-  serverHostKey: [
-    "ssh-rsa",
-    "ecdsa-sha2-nistp256",
-    "ecdsa-sha2-nistp384",
-    "ecdsa-sha2-nistp521",
-    "ssh-ed25519",
-  ],
-  kex: [
-    "ecdh-sha2-nistp256",
-    "ecdh-sha2-nistp384",
-    "ecdh-sha2-nistp521",
-    "diffie-hellman-group14-sha256",
-    "diffie-hellman-group16-sha512",
-    "diffie-hellman-group1-sha1",
-  ],
-  cipher: [
-    "aes128-ctr",
-    "aes256-ctr",
-    "aes128-cbc",
-  ],
-  hmac: [
-    "hmac-sha2-256",
-    "hmac-sha2-512",
-    "hmac-sha1",
-  ],
-  compress: ["none"],
-} as const;
-
-export interface SSHConnectionConfig {
-  host: string;
-  username: string;
-  port?: number;
-  useAgent?: boolean;
-  proxy?: string;
-  proxyCommand?: string;
-  keys?: string[];
-  keyData?: string[];
-  keysOnly?: boolean;
-  dnsRetries?: number;
-  sshConfigFiles?: string[] | false;
-  connectTimeout?: number;
-  keyPath?: string;
-  logLevel?: LogLevel;
-}
-
-export interface CommandResult {
-  stdout: string;
-  stderr: string;
-  success: boolean;
-  code: number | null;
-}
+// Re-export types for convenience
+export type { CommandResult, SSHConnectionConfig };
+export { SSH_ALGORITHMS };
 
 /**
  * SSH connection manager for remote operations


### PR DESCRIPTION
- Extracted logger, lock, and deployment-related TypeScript types into a new shared `types` module
- Updated imports across the codebase to reference the shared `types` module
- Simplified type sharing and reduced duplication by centralizing common types

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #12 
<!-- GitButler Footer Boundary Bottom -->

