### PR TITLE
refactor(logs/deploy): unify output via log.hostOutput and log.say

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -21,85 +21,89 @@ export const buildCommand = new Command()
     let registryManager: RegistryManager | undefined;
 
     try {
-      await log.group("Service Build", async () => {
-        log.info("Starting service build process", "build");
+      const tracker = log.createStepTracker("Service Build");
 
-        const buildOptions = options as unknown as BuildOptions;
-        const globalOptions = options as unknown as GlobalOptions;
-        config = await Configuration.load(
-          globalOptions.environment,
-          globalOptions.configFile,
+      const buildOptions = options as unknown as BuildOptions;
+      const globalOptions = options as unknown as GlobalOptions;
+
+      tracker.step("Loading configuration");
+      config = await Configuration.load(
+        globalOptions.environment,
+        globalOptions.configFile,
+      );
+      const configPath = config.configPath || "unknown";
+      log.say(`Configuration loaded from: ${configPath}`, 1);
+
+      if (!config) throw new Error("Configuration failed to load");
+
+      const engine = config.builder.engine;
+      log.say(`Container engine: ${engine}`, 1);
+
+      let servicesToBuild = config.getBuildServices();
+
+      if (servicesToBuild.length === 0) {
+        log.warn("No services with 'build' configuration found");
+        return;
+      }
+
+      if (buildOptions.services) {
+        servicesToBuild = filterServicesByPatterns(
+          servicesToBuild,
+          buildOptions.services,
+          config,
         );
-        const configPath = config.configPath || "unknown";
-        log.success(`Configuration loaded from: ${configPath}`, "config");
+      }
 
-        if (!config) throw new Error("Configuration failed to load");
+      log.section("Image Building");
+      log.say(
+        `Building ${servicesToBuild.length} service(s): ${
+          servicesToBuild.map((s) => s.name).join(", ")
+        }`,
+      );
 
-        const engine = config.builder.engine;
-        log.info(`Container engine: ${engine}`, "build");
-        let servicesToBuild = config.getBuildServices();
-
-        if (servicesToBuild.length === 0) {
-          log.warn("No services with 'build' configuration found", "build");
-          return;
-        }
-
-        if (buildOptions.services) {
-          servicesToBuild = filterServicesByPatterns(
-            servicesToBuild,
-            buildOptions.services,
-            config,
-          );
-        }
-
-        log.info(
-          `Building ${servicesToBuild.length} service(s): ${
-            servicesToBuild.map((s) => s.name).join(", ")
-          }`,
-          "build",
-        );
-
-        const versionTag = await VersionManager.determineVersionTag({
-          customVersion: globalOptions.version,
-          useGitSha: true,
-          shortSha: true,
-        });
-
-        const registry = config.builder.registry;
-
-        if (buildOptions.push && registry.isLocal()) {
-          await log.group("Local Registry Setup", async () => {
-            registryManager = new RegistryManager(engine, registry.port);
-            await registryManager.setupForBuild();
-          });
-        }
-
-        const buildService = new BuildService({
-          engine,
-          registry,
-          globalOptions,
-          noCache: buildOptions.noCache,
-          push: buildOptions.push,
-          cacheEnabled: config.builder.cache,
-        });
-
-        await buildService.buildServices(servicesToBuild, versionTag);
-
-        log.success(
-          `Successfully built ${servicesToBuild.length} service(s)`,
-          "build",
-        );
-        log.info(`Version tag: ${versionTag}`, "build");
-        if (buildOptions.push) {
-          log.info(`Registry: ${registry.getRegistryUrl()}`, "build");
-        }
+      const versionTag = await VersionManager.determineVersionTag({
+        customVersion: globalOptions.version,
+        useGitSha: true,
+        shortSha: true,
       });
+      log.say(`Version tag: ${versionTag}`, 1);
+
+      const registry = config.builder.registry;
+
+      if (buildOptions.push && registry.isLocal()) {
+        tracker.step("Setting up local registry");
+        registryManager = new RegistryManager(engine, registry.port);
+        await registryManager.setupForBuild();
+      }
+
+      const buildService = new BuildService({
+        engine,
+        registry,
+        globalOptions,
+        noCache: buildOptions.noCache,
+        push: buildOptions.push,
+        cacheEnabled: config.builder.cache,
+      });
+
+      tracker.step(`Building ${servicesToBuild.length} service(s)`);
+      await buildService.buildServices(servicesToBuild, versionTag);
+
+      if (buildOptions.push) {
+        log.say(`Registry: ${registry.getRegistryUrl()}`, 1);
+      }
+
+      tracker.finish();
+
+      console.log();
+      log.success(
+        `Successfully built ${servicesToBuild.length} service(s)`,
+      );
     } catch (error) {
+      console.log();
       log.error(
         `Build failed: ${
           error instanceof Error ? error.message : String(error)
         }`,
-        "build",
       );
       Deno.exit(1);
     }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -28,117 +28,117 @@ async function displayDeploymentPlan(
   deployOptions: DeployOptions,
   globalOptions: GlobalOptions,
 ): Promise<boolean> {
-  await log.group("Deployment Plan", () => {
-    log.info("Analyzing deployment configuration...", "plan");
+  log.section("Deployment Plan");
+  log.say("Analyzing deployment configuration...");
 
-    let allServices = config.getDeployableServices();
+  let allServices = config.getDeployableServices();
 
-    if (deployOptions.services) {
-      allServices = filterServicesByPatterns(
-        allServices,
-        deployOptions.services,
-        config,
-      );
-    }
+  if (deployOptions.services) {
+    allServices = filterServicesByPatterns(
+      allServices,
+      deployOptions.services,
+      config,
+    );
+  }
 
-    let buildServices = config.getBuildServices();
-    if (deployOptions.services) {
-      buildServices = filterServicesByPatterns(
-        buildServices,
-        deployOptions.services,
-        config,
-      );
-    }
+  let buildServices = config.getBuildServices();
+  if (deployOptions.services) {
+    buildServices = filterServicesByPatterns(
+      buildServices,
+      deployOptions.services,
+      config,
+    );
+  }
 
-    log.info("Deployment Plan", "plan");
-    log.info("═".repeat(50), "plan");
-    log.info(`Project: ${config.project}`, "plan");
-    log.info(`Container Engine: ${config.builder.engine}`, "plan");
-    log.info(`Registry: ${config.builder.registry.getRegistryUrl()}`, "plan");
+  console.log();
+  log.say("Deployment Plan");
+  log.say("═".repeat(50));
+  log.say(`Project: ${config.project}`);
+  log.say(`Container Engine: ${config.builder.engine}`);
+  log.say(`Registry: ${config.builder.registry.getRegistryUrl()}`);
 
-    if (globalOptions.version) {
-      log.info(`Version: ${globalOptions.version}`, "plan");
-    }
+  if (globalOptions.version) {
+    log.say(`Version: ${globalOptions.version}`);
+  }
 
-    if (deployOptions.build && buildServices.length > 0) {
-      log.info("Services to Build:", "plan");
-      for (const service of buildServices) {
-        log.info(`  • ${service.name}`, "plan");
-        if (typeof service.build === "string") {
-          log.info(`    Context: ${service.build}`, "plan");
-        } else if (service.build) {
-          log.info(`    Context: ${service.build.context}`, "plan");
-          if (service.build.dockerfile) {
-            log.info(`    Dockerfile: ${service.build.dockerfile}`, "plan");
-          }
-          if (service.build.target) {
-            log.info(`    Target: ${service.build.target}`, "plan");
-          }
+  if (deployOptions.build && buildServices.length > 0) {
+    log.say("Services to Build:");
+    for (const service of buildServices) {
+      log.say(`  • ${service.name}`);
+      if (typeof service.build === "string") {
+        log.say(`    Context: ${service.build}`, 2);
+      } else if (service.build) {
+        log.say(`    Context: ${service.build.context}`, 2);
+        if (service.build.dockerfile) {
+          log.say(`    Dockerfile: ${service.build.dockerfile}`, 2);
+        }
+        if (service.build.target) {
+          log.say(`    Target: ${service.build.target}`, 2);
         }
       }
     }
+  }
 
-    log.info("Services to Deploy:", "plan");
-    if (allServices.length === 0) {
-      log.info("  No services to deploy", "plan");
-    } else {
-      for (const service of allServices) {
-        log.info(`  ${service.name}`, "plan");
+  log.say("Services to Deploy:");
+  if (allServices.length === 0) {
+    log.say("  No services to deploy");
+  } else {
+    for (const service of allServices) {
+      log.say(`  ${service.name}`);
 
-        if (service.image) {
-          log.info(`    Image: ${service.image}`, "plan");
-        } else if (service.build) {
-          log.info(
-            `    Built from: ${
-              typeof service.build === "string"
-                ? service.build
-                : service.build.context
-            }`,
-            "plan",
-          );
-        }
+      if (service.image) {
+        log.say(`    Image: ${service.image}`, 2);
+      } else if (service.build) {
+        log.say(
+          `    Built from: ${
+            typeof service.build === "string"
+              ? service.build
+              : service.build.context
+          }`,
+          2,
+        );
+      }
 
-        if (service.servers.length > 0) {
-          log.info(
-            `    Servers: ${service.servers.map((s) => s.host).join(", ")}`,
-            "plan",
-          );
-        }
+      if (service.servers.length > 0) {
+        log.say(
+          `    Servers: ${service.servers.map((s) => s.host).join(", ")}`,
+          2,
+        );
+      }
 
-        if (service.ports.length > 0) {
-          log.info(`    Ports: ${service.ports.join(", ")}`, "plan");
-        }
+      if (service.ports.length > 0) {
+        log.say(`    Ports: ${service.ports.join(", ")}`, 2);
+      }
 
-        if (service.proxy?.enabled) {
-          const hosts = service.proxy.hosts.length > 0
-            ? service.proxy.hosts.join(", ")
-            : "auto";
-          log.info(`    Proxy: Enabled (${hosts})`, "plan");
-        }
+      if (service.proxy?.enabled) {
+        const hosts = service.proxy.hosts.length > 0
+          ? service.proxy.hosts.join(", ")
+          : "auto";
+        log.say(`    Proxy: Enabled (${hosts})`, 2);
       }
     }
+  }
 
-    const options: string[] = [];
-    if (deployOptions.build) options.push("Build images");
-    if (deployOptions.noCache) options.push("No cache");
-    if (globalOptions.hosts) {
-      options.push(`Target hosts: ${globalOptions.hosts}`);
-    }
+  const options: string[] = [];
+  if (deployOptions.build) options.push("Build images");
+  if (deployOptions.noCache) options.push("No cache");
+  if (globalOptions.hosts) {
+    options.push(`Target hosts: ${globalOptions.hosts}`);
+  }
 
-    if (options.length > 0) {
-      log.info("\nOptions:", "plan");
-      options.forEach((option) => log.info(`  • ${option}`, "plan"));
-    }
+  if (options.length > 0) {
+    log.say("\nOptions:");
+    options.forEach((option) => log.say(`  • ${option}`));
+  }
 
-    log.info("═".repeat(50), "plan");
-  });
+  log.say("═".repeat(50));
+  console.log();
 
   if (deployOptions.yes) {
-    log.info("Skipping confirmation (--yes flag provided)", "plan");
+    log.say("Proceeding with deployment (--yes flag provided)");
     return true;
   }
 
-  log.info("", "plan");
   const confirmed = await Confirm.prompt({
     message: "Do you want to proceed with this deployment?",
     default: false,
@@ -161,235 +161,205 @@ export const deployCommand = new Command()
     let portForwardManager: PortForwardManager | undefined;
 
     try {
-      await log.group("Service Deployment", async () => {
-        log.info("Starting service deployment process", "deploy");
+      log.section("Service Deployment");
+      log.say("Starting service deployment process");
 
-        const config = await Configuration.load(
-          globalOptions.environment,
-          globalOptions.configFile,
-        );
-        log.success(
-          `Configuration loaded from: ${config.configPath || "unknown"}`,
-          "config",
-        );
-        log.info(`Container engine: ${config.builder.engine}`, "engine");
+      const config = await Configuration.load(
+        globalOptions.environment,
+        globalOptions.configFile,
+      );
+      log.say(`Container engine: ${config.builder.engine}`);
 
-        const shouldProceed = await displayDeploymentPlan(
-          config,
-          deployOptions,
-          globalOptions,
-        );
-        if (!shouldProceed) {
-          log.info("Deployment cancelled by user", "deploy");
-          return;
-        }
+      const shouldProceed = await displayDeploymentPlan(
+        config,
+        deployOptions,
+        globalOptions,
+      );
+      if (!shouldProceed) {
+        log.say("Deployment cancelled by user");
+        return;
+      }
 
-        if (deployOptions.build) {
-          await log.group("Service Build", async () => {
-            log.info("Building service images", "build");
+      if (deployOptions.build) {
+        const buildTracker = log.createStepTracker("Building Service Images");
 
-            const servicesToBuild = config.getBuildServices();
+        const servicesToBuild = config.getBuildServices();
 
-            if (servicesToBuild.length === 0) {
-              log.warn("No services with 'build' configuration found", "build");
-            } else {
-              let filteredServices = servicesToBuild;
-              if (deployOptions.services) {
-                filteredServices = filterServicesByPatterns(
-                  servicesToBuild,
-                  deployOptions.services,
-                  config,
-                );
-              }
-
-              log.info(
-                `Building ${filteredServices.length} service(s): ${
-                  filteredServices.map((s) => s.name).join(", ")
-                }`,
-                "build",
-              );
-
-              const versionTag = await VersionManager.determineVersionTag({
-                customVersion: globalOptions.version,
-                useGitSha: true,
-                shortSha: true,
-                isImageService: false, // These are build services
-                serviceName: filteredServices.map((s) => s.name).join(", "),
-              });
-
-              const registry = config.builder.registry;
-              let registryManager: RegistryManager | undefined;
-
-              if (registry.isLocal()) {
-                await log.group("Local Registry Setup", async () => {
-                  registryManager = new RegistryManager(
-                    config.builder.engine,
-                    registry.port,
-                  );
-                  await registryManager.setupForBuild();
-                });
-              }
-
-              const buildService = new BuildService({
-                engine: config.builder.engine,
-                registry,
-                globalOptions,
-                noCache: deployOptions.noCache,
-                push: true, // Deploy always pushes images
-                cacheEnabled: config.builder.cache,
-              });
-
-              await buildService.buildServices(filteredServices, versionTag);
-
-              log.success(
-                `Successfully built ${filteredServices.length} service(s)`,
-                "build",
-              );
-              log.info(`Version tag: ${versionTag}`, "build");
-              log.info(`Registry: ${registry.getRegistryUrl()}`, "build");
-            }
-          });
-        }
-
-        ctx = await setupCommandContext(globalOptions);
-        const { sshManagers, targetHosts } = ctx;
-
-        if (config.builder.registry.isLocal()) {
-          await log.group("Local Registry Port Forwarding", async () => {
-            const registryPort = config.builder.registry.port;
-            log.info(
-              `Setting up reverse port forwarding for local registry (port ${registryPort})`,
-              "registry",
-            );
-
-            portForwardManager = new PortForwardManager();
-
-            for (const ssh of sshManagers) {
-              const host = ssh.getHost();
-              log.status(
-                `Establishing port forward to ${host}`,
-                "port-forward",
-              );
-
-              const forwarder = portForwardManager.getForwarder(
-                host,
-                ssh,
-                registryPort,
-                registryPort,
-              );
-
-              try {
-                await forwarder.startForwarding();
-                log.success(
-                  `Port forwarding active for ${host}`,
-                  "port-forward",
-                );
-              } catch (error) {
-                log.warn(
-                  `Failed to set up port forwarding for ${host}: ${
-                    error instanceof Error ? error.message : String(error)
-                  }`,
-                  "port-forward",
-                );
-              }
-            }
-
-            log.info(
-              `Local registry accessible on remote hosts via localhost:${registryPort}`,
-              "registry",
-            );
-          });
-        }
-
-        let allServices = config.getDeployableServices();
-
-        if (deployOptions.services) {
-          allServices = filterServicesByPatterns(
-            allServices,
-            deployOptions.services,
-            config,
-          );
-
-          log.info(
-            `Deploying ${allServices.length} service(s): ${
-              allServices.map((s) => s.name).join(", ")
-            }`,
-            "deploy",
-          );
+        if (servicesToBuild.length === 0) {
+          buildTracker.step("No services with 'build' configuration found");
         } else {
-          log.info(
-            `Deploying all ${allServices.length} service(s): ${
-              allServices.map((s) => s.name).join(", ")
+          let filteredServices = servicesToBuild;
+          if (deployOptions.services) {
+            filteredServices = filterServicesByPatterns(
+              servicesToBuild,
+              deployOptions.services,
+              config,
+            );
+          }
+
+          buildTracker.step(
+            `Building ${filteredServices.length} service(s): ${
+              filteredServices.map((s) => s.name).join(", ")
             }`,
-            "deploy",
           );
+
+          const versionTag = await VersionManager.determineVersionTag({
+            customVersion: globalOptions.version,
+            useGitSha: true,
+            shortSha: true,
+            isImageService: false,
+            serviceName: filteredServices.map((s) => s.name).join(", "),
+          });
+
+          const registry = config.builder.registry;
+          let registryManager: RegistryManager | undefined;
+
+          if (registry.isLocal()) {
+            buildTracker.step("Setting up local registry...");
+            registryManager = new RegistryManager(
+              config.builder.engine,
+              registry.port,
+            );
+            await registryManager.setupForBuild();
+          }
+
+          const buildService = new BuildService({
+            engine: config.builder.engine,
+            registry,
+            globalOptions,
+            noCache: deployOptions.noCache,
+            push: true,
+            cacheEnabled: config.builder.cache,
+          });
+
+          await buildService.buildServices(filteredServices, versionTag);
+
+          buildTracker.step(`Version tag: ${versionTag}`);
+          buildTracker.step(`Registry: ${registry.getRegistryUrl()}`);
         }
 
-        // Use DeploymentOrchestrator for complex deployment workflow
-        const orchestrator = new DeploymentOrchestrator(config, sshManagers);
+        buildTracker.finish();
+      }
 
-        const orchestrationResult = await orchestrator.orchestrateDeployment(
+      ctx = await setupCommandContext(globalOptions);
+      const { sshManagers, targetHosts } = ctx;
+
+      if (config.builder.registry.isLocal()) {
+        const portTracker = log.createStepTracker(
+          "Setting Up Local Registry Access",
+        );
+
+        const registryPort = config.builder.registry.port;
+        portForwardManager = new PortForwardManager();
+
+        for (const ssh of sshManagers) {
+          const host = ssh.getHost();
+
+          const forwarder = portForwardManager.getForwarder(
+            host,
+            ssh,
+            registryPort,
+            registryPort,
+          );
+
+          try {
+            await forwarder.startForwarding();
+            portTracker.remote(host, "Port forwarding established");
+          } catch (error) {
+            portTracker.remote(
+              host,
+              `Failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+          }
+        }
+
+        portTracker.finish();
+      }
+
+      let allServices = config.getDeployableServices();
+
+      if (deployOptions.services) {
+        allServices = filterServicesByPatterns(
           allServices,
-          targetHosts,
+          deployOptions.services,
+          config,
+        );
+      }
+
+      const serviceNames = allServices.map((s) => s.name).join(", ");
+      log.say(
+        `Deploying ${allServices.length} service${
+          allServices.length === 1 ? "" : "s"
+        }: ${serviceNames}`,
+      );
+
+      // Use DeploymentOrchestrator for complex deployment workflow
+      const orchestrator = new DeploymentOrchestrator(config, sshManagers);
+
+      const orchestrationResult = await orchestrator.orchestrateDeployment(
+        allServices,
+        targetHosts,
+        {
+          version: globalOptions.version,
+          allSshManagers: sshManagers,
+        },
+      );
+
+      // Log structured deployment summary
+      orchestrator.logDeploymentSummary(orchestrationResult);
+
+      // Image cleanup for successful deployments
+      if (
+        allServices.length > 0 &&
+        orchestrationResult.deploymentResults.some((r) => r.success)
+      ) {
+        const pruneTracker = log.createStepTracker("Image Cleanup");
+
+        const pruneService = new ImagePruneService(
+          config.builder.engine,
+          config.project,
+        );
+
+        const maxRetain = Math.max(...allServices.map((s) => s.retain));
+        pruneTracker.step(
+          `Pruning old images (retaining last ${maxRetain} per service)`,
+        );
+
+        const pruneResults = await pruneService.pruneImagesOnHosts(
+          sshManagers,
           {
-            version: globalOptions.version,
-            allSshManagers: sshManagers,
+            retain: maxRetain,
+            removeDangling: true,
           },
         );
 
-        // Log structured deployment summary
-        orchestrator.logDeploymentSummary(orchestrationResult);
+        const totalRemoved = pruneResults.reduce(
+          (sum, r) => sum + r.imagesRemoved,
+          0,
+        );
 
-        // Image cleanup for successful deployments
-        if (
-          allServices.length > 0 &&
-          orchestrationResult.deploymentResults.some((r) => r.success)
-        ) {
-          await log.group("Image Cleanup", async () => {
-            log.info(
-              "Pruning old images to retain configured versions",
-              "prune",
-            );
-
-            const pruneService = new ImagePruneService(
-              config.builder.engine,
-              config.project,
-            );
-
-            const maxRetain = Math.max(...allServices.map((s) => s.retain));
-            log.info(
-              `Retaining up to ${maxRetain} image(s) per service`,
-              "prune",
-            );
-
-            const pruneResults = await pruneService.pruneImagesOnHosts(
-              sshManagers,
-              {
-                retain: maxRetain,
-                removeDangling: true,
-              },
-            );
-
-            const totalRemoved = pruneResults.reduce(
-              (sum, r) => sum + r.imagesRemoved,
-              0,
-            );
-
-            if (totalRemoved > 0) {
-              log.success(
-                `Pruned ${totalRemoved} old image(s) across ${pruneResults.length} server(s)`,
-                "prune",
+        if (totalRemoved > 0) {
+          for (const result of pruneResults) {
+            if (result.imagesRemoved > 0) {
+              pruneTracker.remote(
+                result.host,
+                `Pruned ${result.imagesRemoved} image(s)`,
               );
-            } else {
-              log.info("No old images to prune", "prune");
             }
-          });
-        } else if (allServices.length === 0) {
-          log.info("No services found to deploy", "deploy");
+          }
+        } else {
+          pruneTracker.step("No old images to prune");
         }
 
-        log.success("Deployment process completed", "deploy");
-      });
+        pruneTracker.finish();
+      } else if (allServices.length === 0) {
+        log.say("No services found to deploy");
+      }
+
+      console.log();
+      log.say("Deployment process completed");
     } catch (error) {
       await handleCommandError(error, {
         operation: "Deployment",

--- a/src/commands/proxy/logs.ts
+++ b/src/commands/proxy/logs.ts
@@ -116,9 +116,9 @@ async function followProxyLogs(
   },
 ): Promise<void> {
   const primaryHost = context.targetHosts[0];
-  log.info(
+  log.action(
     `Following logs from ${KAMAL_PROXY_CONTAINER_NAME} on ${primaryHost}...`,
-    "proxy-logs",
+    "magenta",
   );
 
   const ssh = context.sshManagers.find((ssh) => ssh.getHost() === primaryHost);
@@ -146,31 +146,24 @@ async function fetchProxyLogs(
     since?: string;
   },
 ): Promise<void> {
-  await log.group("Proxy Logs", async () => {
-    log.info(
-      `Fetching logs from ${KAMAL_PROXY_CONTAINER_NAME}...`,
-      "proxy-logs",
-    );
+  log.action(
+    `Fetching logs from ${KAMAL_PROXY_CONTAINER_NAME}...`,
+    "magenta",
+  );
 
-    // Fetch logs from each host
-    for (const host of context.targetHosts) {
-      const ssh = context.sshManagers.find((ssh) => ssh.getHost() === host);
-      if (!ssh) {
-        log.warn(`SSH connection not found for host ${host}`, "proxy-logs");
-        continue;
-      }
-
-      log.info(
-        `Logs from ${KAMAL_PROXY_CONTAINER_NAME} on ${host}:`,
-        "proxy-logs",
-      );
-
-      await logsService.fetchContainerLogs(
-        ssh,
-        host,
-        KAMAL_PROXY_CONTAINER_NAME,
-        logOptions,
-      );
+  // Fetch logs from each host
+  for (const host of context.targetHosts) {
+    const ssh = context.sshManagers.find((ssh) => ssh.getHost() === host);
+    if (!ssh) {
+      log.warn(`SSH connection not found for host ${host}`, "proxy-logs");
+      continue;
     }
-  });
+
+    await logsService.fetchContainerLogs(
+      ssh,
+      host,
+      KAMAL_PROXY_CONTAINER_NAME,
+      logOptions,
+    );
+  }
 }

--- a/src/commands/server/exec.ts
+++ b/src/commands/server/exec.ts
@@ -39,7 +39,7 @@ export const execCommand = new Command()
 
     try {
       await log.group("Remote Command Execution", async () => {
-        log.info(`Executing command: ${command}`, "exec");
+        log.action(`Executing command: ${command}`, "magenta");
 
         // Set up command context
         ctx = await setupCommandContext(globalOptions, {
@@ -54,229 +54,227 @@ export const execCommand = new Command()
           config.project,
         );
 
-        await log.group("Command Execution", async () => {
-          log.info(`Interactive mode: ${options.interactive}`, "exec");
-          log.info(
-            `Execution mode: ${options.parallel ? "parallel" : "sequential"}`,
-            "exec",
-          );
-          log.info(`Timeout: ${options.timeout} seconds`, "exec");
-          log.info(`Continue on error: ${options.continueOnError}`, "exec");
+        log.info(`Interactive mode: ${options.interactive}`, "exec");
+        log.info(
+          `Execution mode: ${options.parallel ? "parallel" : "sequential"}`,
+          "exec",
+        );
+        log.info(`Timeout: ${options.timeout} seconds`, "exec");
+        log.info(`Continue on error: ${options.continueOnError}`, "exec");
 
-          // Handle interactive mode
-          if (options.interactive) {
-            if (sshManagers.length > 1) {
-              log.error(
-                "Interactive mode only supports single host execution",
-                "exec",
+        // Handle interactive mode
+        if (options.interactive) {
+          if (sshManagers.length > 1) {
+            log.error(
+              "Interactive mode only supports single host execution",
+              "exec",
+            );
+            log.info(
+              `Found ${sshManagers.length} hosts. Please specify a single host for interactive mode.`,
+              "exec",
+            );
+            return;
+          }
+
+          log.action("Starting interactive session...", "cyan");
+          const ssh = sshManagers[0];
+
+          try {
+            await ssh.startInteractiveSession(command);
+            Deno.exit(0);
+          } catch (error) {
+            const errorMessage = error instanceof Error
+              ? error.message
+              : String(error);
+            log.error(`Interactive session failed: ${errorMessage}`, "exec");
+            Deno.exit(1);
+          }
+        }
+
+        // Create server loggers for individual host reporting
+        const serverLoggers = Logger.forServers(targetHosts, {
+          maxPrefixLength: DEFAULT_MAX_PREFIX_LENGTH,
+        });
+
+        // Execute the command on all hosts
+        const executionResults = [];
+
+        if (options.parallel) {
+          log.action("Executing command in parallel...", "cyan");
+
+          // Create host operations
+          const hostOperations = sshManagers.map((ssh) => ({
+            host: ssh.getHost(),
+            operation: async () => {
+              return await executeCommandWithTimeout(
+                ssh,
+                command,
+                options.timeout,
+                serverLoggers,
               );
-              log.info(
-                `Found ${sshManagers.length} hosts. Please specify a single host for interactive mode.`,
-                "exec",
-              );
-              return;
+            },
+          }));
+
+          // Execute with error collection
+          const aggregatedResults = await executeHostOperations(
+            hostOperations,
+          );
+
+          // Combine successful results with failed operations
+          const results = [...aggregatedResults.results];
+
+          // Convert failed operations to execution result format
+          for (const { host, error } of aggregatedResults.hostErrors) {
+            const hostLogger = serverLoggers.get(host);
+            if (hostLogger) {
+              hostLogger.error(`Command execution failed: ${error.message}`);
             }
 
-            log.status("Starting interactive session...", "exec");
-            const ssh = sshManagers[0];
+            results.push({
+              host,
+              success: false,
+              code: -1,
+              stdout: "",
+              stderr: error.message,
+            });
+          }
+
+          executionResults.push(...results);
+
+          // Log summary
+          if (aggregatedResults.errorCount > 0) {
+            log.warn(
+              `Parallel execution completed with ${aggregatedResults.errorCount} failures out of ${results.length} hosts`,
+              "exec",
+            );
+          } else {
+            log.success(
+              `Parallel execution completed successfully on all ${results.length} hosts`,
+              "exec",
+            );
+          }
+        } else {
+          log.action("Executing command sequentially...", "cyan");
+
+          // Execute sequentially
+          for (const ssh of sshManagers) {
+            const host = ssh.getHost();
 
             try {
-              await ssh.startInteractiveSession(command);
-              Deno.exit(0);
+              const result = await executeCommandWithTimeout(
+                ssh,
+                command,
+                options.timeout,
+                serverLoggers,
+              );
+
+              executionResults.push({
+                host,
+                result,
+                success: result.success,
+              });
+
+              // Stop on first failure if continue-on-error is false
+              if (!result.success && !options.continueOnError) {
+                log.error(
+                  `Command failed on ${host}, stopping execution`,
+                  "exec",
+                );
+                break;
+              }
             } catch (error) {
               const errorMessage = error instanceof Error
                 ? error.message
                 : String(error);
-              log.error(`Interactive session failed: ${errorMessage}`, "exec");
-              Deno.exit(1);
-            }
-          }
 
-          // Create server loggers for individual host reporting
-          const serverLoggers = Logger.forServers(targetHosts, {
-            maxPrefixLength: DEFAULT_MAX_PREFIX_LENGTH,
-          });
-
-          // Execute the command on all hosts
-          const executionResults = [];
-
-          if (options.parallel) {
-            log.status("Executing command in parallel...", "exec");
-
-            // Create host operations
-            const hostOperations = sshManagers.map((ssh) => ({
-              host: ssh.getHost(),
-              operation: async () => {
-                return await executeCommandWithTimeout(
-                  ssh,
-                  command,
-                  options.timeout,
-                  serverLoggers,
-                );
-              },
-            }));
-
-            // Execute with error collection
-            const aggregatedResults = await executeHostOperations(
-              hostOperations,
-            );
-
-            // Combine successful results with failed operations
-            const results = [...aggregatedResults.results];
-
-            // Convert failed operations to execution result format
-            for (const { host, error } of aggregatedResults.hostErrors) {
               const hostLogger = serverLoggers.get(host);
               if (hostLogger) {
-                hostLogger.error(`Command execution failed: ${error.message}`);
+                hostLogger.error(`Command failed: ${errorMessage}`);
               }
 
-              results.push({
+              executionResults.push({
                 host,
-                success: false,
-                code: -1,
-                stdout: "",
-                stderr: error.message,
-              });
-            }
-
-            executionResults.push(...results);
-
-            // Log summary
-            if (aggregatedResults.errorCount > 0) {
-              log.warn(
-                `Parallel execution completed with ${aggregatedResults.errorCount} failures out of ${results.length} hosts`,
-                "exec",
-              );
-            } else {
-              log.success(
-                `Parallel execution completed successfully on all ${results.length} hosts`,
-                "exec",
-              );
-            }
-          } else {
-            log.status("Executing command sequentially...", "exec");
-
-            // Execute sequentially
-            for (const ssh of sshManagers) {
-              const host = ssh.getHost();
-
-              try {
-                const result = await executeCommandWithTimeout(
-                  ssh,
-                  command,
-                  options.timeout,
-                  serverLoggers,
-                );
-
-                executionResults.push({
-                  host,
-                  result,
-                  success: result.success,
-                });
-
-                // Stop on first failure if continue-on-error is false
-                if (!result.success && !options.continueOnError) {
-                  log.error(
-                    `Command failed on ${host}, stopping execution`,
-                    "exec",
-                  );
-                  break;
-                }
-              } catch (error) {
-                const errorMessage = error instanceof Error
-                  ? error.message
-                  : String(error);
-
-                const hostLogger = serverLoggers.get(host);
-                if (hostLogger) {
-                  hostLogger.error(`Command failed: ${errorMessage}`);
-                }
-
-                executionResults.push({
-                  host,
-                  result: {
-                    stdout: "",
-                    stderr: errorMessage,
-                    success: false,
-                    code: null,
-                  },
+                result: {
+                  stdout: "",
+                  stderr: errorMessage,
                   success: false,
-                  error: errorMessage,
-                });
+                  code: null,
+                },
+                success: false,
+                error: errorMessage,
+              });
 
-                // Stop on first failure if continue-on-error is false
-                if (!options.continueOnError) {
-                  log.error(
-                    `Command failed on ${host}, stopping execution`,
-                    "exec",
-                  );
-                  break;
-                }
+              // Stop on first failure if continue-on-error is false
+              if (!options.continueOnError) {
+                log.error(
+                  `Command failed on ${host}, stopping execution`,
+                  "exec",
+                );
+                break;
               }
             }
           }
+        }
 
-          // Summary
-          const successful = executionResults.filter((r) => r.success);
-          const failed = executionResults.filter((r) => !r.success);
+        // Summary
+        const successful = executionResults.filter((r) => r.success);
+        const failed = executionResults.filter((r) => !r.success);
 
-          log.info("Execution Summary:", "exec");
-          log.success(
-            `Successful: ${successful.length} host(s) - ${
-              successful.map((r) => r.host).join(", ")
+        log.info("Execution Summary:", "exec");
+        log.success(
+          `Successful: ${successful.length} host(s) - ${
+            successful.map((r) => r.host).join(", ")
+          }`,
+          "exec",
+        );
+
+        if (failed.length > 0) {
+          log.error(
+            `Failed: ${failed.length} host(s) - ${
+              failed.map((r) => r.host).join(", ")
             }`,
             "exec",
           );
+        }
 
-          if (failed.length > 0) {
-            log.error(
-              `Failed: ${failed.length} host(s) - ${
-                failed.map((r) => r.host).join(", ")
-              }`,
-              "exec",
-            );
-          }
+        // Overall success/failure
+        if (failed.length > 0 && !options.continueOnError) {
+          log.error("Command execution failed on some hosts", "exec");
 
-          // Overall success/failure
-          if (failed.length > 0 && !options.continueOnError) {
-            log.error("Command execution failed on some hosts", "exec");
-
-            // Log failures to audit before exiting
-            await auditLogger.logCustomCommand(
-              command,
-              "failed",
-              `Command execution failed on ${failed.length} host(s): ${
-                failed.map((r) => r.host).join(", ")
-              }`,
-            );
-
-            Deno.exit(1);
-          } else if (failed.length === 0) {
-            log.success("Command executed successfully on all hosts", "exec");
-          } else {
-            log.warn(
-              `Command completed with some failures (${failed.length}/${executionResults.length} hosts failed)`,
-              "exec",
-            );
-          }
-
-          // Log completion to audit
+          // Log failures to audit before exiting
           await auditLogger.logCustomCommand(
             command,
-            failed.length === 0 ? "success" : "failed",
-            failed.length === 0
-              ? `Command executed successfully on all ${successful.length} host(s)`
-              : `Command completed with ${failed.length} failure(s) out of ${executionResults.length} host(s)`,
+            "failed",
+            `Command execution failed on ${failed.length} host(s): ${
+              failed.map((r) => r.host).join(", ")
+            }`,
           );
 
-          log.info(
-            `Audit trail updated on ${targetHosts.length} server(s): ${
-              targetHosts.join(", ")
-            }`,
-            "audit",
+          Deno.exit(1);
+        } else if (failed.length === 0) {
+          log.success("Command executed successfully on all hosts", "exec");
+        } else {
+          log.warn(
+            `Command completed with some failures (${failed.length}/${executionResults.length} hosts failed)`,
+            "exec",
           );
-        });
+        }
+
+        // Log completion to audit
+        await auditLogger.logCustomCommand(
+          command,
+          failed.length === 0 ? "success" : "failed",
+          failed.length === 0
+            ? `Command executed successfully on all ${successful.length} host(s)`
+            : `Command completed with ${failed.length} failure(s) out of ${executionResults.length} host(s)`,
+        );
+
+        log.info(
+          `Audit trail updated on ${targetHosts.length} server(s): ${
+            targetHosts.join(", ")
+          }`,
+          "audit",
+        );
 
         console.log();
         log.success("Remote command execution completed!");
@@ -336,28 +334,23 @@ async function executeCommandWithTimeout(
       timeoutPromise,
     ]) as Awaited<ReturnType<typeof ssh.executeCommand>>;
 
-    if (hostLogger) {
-      if (result.success) {
-        hostLogger.success(
-          `Command completed (exit code: ${result.code})`,
-        );
-      } else {
-        hostLogger.error(
-          `Command failed (exit code: ${result.code})`,
-        );
-      }
-
-      if (result.stdout.trim()) {
-        result.stdout.trim().split("\n").forEach((line) => {
-          hostLogger.info(`STDOUT: ${line}`);
-        });
-      }
-      if (result.stderr.trim()) {
-        result.stderr.trim().split("\n").forEach((line) => {
-          hostLogger.warn(`STDERR: ${line}`);
-        });
-      }
+    // Format output for host
+    let output = "";
+    if (result.success) {
+      output += `Command completed (exit code: ${result.code})\n`;
+    } else {
+      output += `Command failed (exit code: ${result.code})\n`;
     }
+
+    if (result.stdout.trim()) {
+      output += result.stdout.trim() + "\n";
+    }
+    if (result.stderr.trim()) {
+      output += "STDERR:\n" + result.stderr.trim() + "\n";
+    }
+
+    // Use host-grouped output
+    log.hostOutput(host, output.trim(), { type: "Exec" });
 
     return {
       host,

--- a/src/commands/server/init.ts
+++ b/src/commands/server/init.ts
@@ -3,11 +3,10 @@ import { getEngineCommand } from "../../utils/config.ts";
 import { setupCommandContext } from "../../utils/command_helpers.ts";
 import { installEngineOnHosts } from "../../utils/engine.ts";
 import { createServerAuditLogger } from "../../utils/audit.ts";
-import { log, Logger } from "../../utils/logger.ts";
+import { log } from "../../utils/logger.ts";
 import { handleCommandError } from "../../utils/error_handler.ts";
 import type { GlobalOptions } from "../../types.ts";
 import { setupNetwork } from "../../lib/network/setup.ts";
-import { DEFAULT_MAX_PREFIX_LENGTH } from "../../constants.ts";
 
 export const initCommand = new Command()
   .description("Initialize servers")
@@ -16,237 +15,214 @@ export const initCommand = new Command()
     let ctx: Awaited<ReturnType<typeof setupCommandContext>> | undefined;
 
     try {
-      await log.group("Server Initialization", async () => {
-        log.info("Starting server initialization process", "init");
+      log.section("Server Initialization");
+      log.say("Starting server initialization process");
 
-        // Set up command context (config, SSH, filtering)
-        ctx = await setupCommandContext(globalOptions);
+      // Set up command context (config, SSH, filtering)
+      ctx = await setupCommandContext(globalOptions);
 
-        const { config, sshManagers, targetHosts } = ctx;
-        const configPath = config.configPath || "unknown";
+      const { config, sshManagers, targetHosts } = ctx;
+      const configPath = config.configPath || "unknown";
 
-        log.info(`Container engine: ${config.builder.engine}`, "engine");
+      log.say(`Container engine: ${config.builder.engine}`);
 
-        // Check if the specified engine is available
-        const engineCommand = getEngineCommand(config);
+      // Check if the specified engine is available
+      const engineCommand = getEngineCommand(config);
 
-        // Create audit logger for connected servers
-        const auditLogger = createServerAuditLogger(
+      // Create audit logger for connected servers
+      const auditLogger = createServerAuditLogger(
+        sshManagers,
+        config.project,
+      );
+
+      // Log initialization start to connected servers
+      await auditLogger.logInitStart(
+        targetHosts,
+        config.builder.engine,
+      );
+
+      // Log configuration loading to connected servers
+      await auditLogger.logConfigChange(configPath, "loaded");
+
+      // Install engine on hosts
+      const installTracker = log.createStepTracker(
+        `${engineCommand} Installation`,
+      );
+
+      installTracker.step(
+        `Installing ${engineCommand} on ${targetHosts.length} host(s)...`,
+      );
+
+      try {
+        const installResults = await installEngineOnHosts(
           sshManagers,
-          config.project,
-        );
-
-        // Log initialization start to connected servers
-        await auditLogger.logInitStart(
-          targetHosts,
           config.builder.engine,
+          installTracker,
         );
 
-        // Log configuration loading to connected servers
-        await auditLogger.logConfigChange(configPath, "loaded");
-
-        // Install engine on hosts
-        await log.group(`${engineCommand} Installation`, async () => {
-          log.status(
-            `Installing ${engineCommand} on remote hosts...`,
-            "install",
-          );
-
-          try {
-            const installResults = await installEngineOnHosts(
-              sshManagers,
-              config.builder.engine,
+        // Log engine installation results to each respective server
+        for (const result of installResults) {
+          if (result.success) {
+            installTracker.remote(
+              result.host,
+              result.message || "Installation successful",
             );
-
-            // Create server loggers for individual host reporting
-            const serverLoggers = Logger.forServers(targetHosts, {
-              maxPrefixLength: DEFAULT_MAX_PREFIX_LENGTH,
-            });
-
-            // Log engine installation results to each respective server
-            for (const result of installResults) {
-              const hostLogger = serverLoggers.get(result.host);
-              if (hostLogger) {
-                if (result.success) {
-                  hostLogger.success(
-                    result.message || "Installation successful",
-                  );
-                } else {
-                  hostLogger.error(
-                    result.error || result.message || "Installation failed",
-                  );
-                }
-              }
-
-              // Also log to audit trail
-              const hostSsh = sshManagers.find((ssh) =>
-                ssh.getHost() === result.host
-              );
-              if (hostSsh) {
-                const hostAuditLogger = createServerAuditLogger(
-                  hostSsh,
-                  config.project,
-                );
-                await hostAuditLogger.logEngineInstall(
-                  config.builder.engine,
-                  result.success ? "success" : "failed",
-                  result.message ||
-                    (result.success ? "Installation successful" : result.error),
-                );
-              }
-            }
-
-            const successfulInstalls = installResults.filter((r) =>
-              r.success
-            ).length;
-            const failedInstalls = installResults.filter((r) =>
-              !r.success
-            ).length;
-
-            if (successfulInstalls > 0) {
-              log.success(
-                `${engineCommand} installed successfully on ${successfulInstalls} host(s)`,
-                "install",
-              );
-            }
-
-            if (failedInstalls > 0) {
-              const msg =
-                `${engineCommand} installation failed on ${failedInstalls} host(s)`;
-              log.warn(msg, "install");
-              throw new Error(msg);
-            }
-          } catch (error) {
-            const errorMessage = error instanceof Error
-              ? error.message
-              : String(error);
-            log.error(
-              `Engine installation failed: ${errorMessage}`,
-              "install",
+          } else {
+            installTracker.remote(
+              result.host,
+              `Failed: ${
+                result.error || result.message || "Installation failed"
+              }`,
             );
-
-            // Log engine installation failure
-            for (const host of targetHosts) {
-              const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
-              if (hostSsh) {
-                const hostLogger = createServerAuditLogger(
-                  hostSsh,
-                  config.project,
-                );
-                await hostLogger.logEngineInstall(
-                  config.builder.engine,
-                  "failed",
-                  errorMessage,
-                );
-              }
-            }
-
-            throw error;
           }
-        });
 
-        // Network setup (if enabled)
-        if (config.network.enabled) {
-          try {
-            const networkResults = await setupNetwork(config, sshManagers);
-
-            // Log network setup results
-            const successfulSetups = networkResults.filter((r) => r.success);
-            const failedSetups = networkResults.filter((r) => !r.success);
-
-            if (successfulSetups.length > 0) {
-              log.success(
-                `Private network configured on ${successfulSetups.length} server(s)`,
-                "network",
-              );
-            }
-
-            if (failedSetups.length > 0) {
-              log.error(
-                `Network setup failed on ${failedSetups.length} server(s)`,
-                "network",
-              );
-              for (const result of failedSetups) {
-                log.error(
-                  `${result.host}: ${result.error || "Unknown error"}`,
-                  "network",
-                );
-              }
-
-              // Throw error for critical network component failures
-              const criticalErrors = failedSetups.map((r) =>
-                `${r.host}: ${r.error || "Network setup failed"}`
-              ).join("; ");
-              throw new Error(
-                `Critical network setup failures: ${criticalErrors}`,
-              );
-            }
-
-            // Log network setup to audit trail
-            for (const result of networkResults) {
-              const hostSsh = sshManagers.find((ssh) =>
-                ssh.getHost() === result.host
-              );
-              if (hostSsh) {
-                const hostLogger = createServerAuditLogger(
-                  hostSsh,
-                  config.project,
-                );
-                await hostLogger.logCustomCommand(
-                  "network_setup",
-                  result.success ? "success" : "failed",
-                  result.message || result.error,
-                );
-              }
-            }
-          } catch (error) {
-            const errorMessage = error instanceof Error
-              ? error.message
-              : String(error);
-            log.error(`Network setup failed: ${errorMessage}`, "network");
-
-            // Log network setup failure
-            for (const host of targetHosts) {
-              const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
-              if (hostSsh) {
-                const hostLogger = createServerAuditLogger(
-                  hostSsh,
-                  config.project,
-                );
-                await hostLogger.logCustomCommand(
-                  "network_setup",
-                  "failed",
-                  errorMessage,
-                );
-              }
-            }
-
-            throw error;
+          // Also log to audit trail
+          const hostSsh = sshManagers.find((ssh) =>
+            ssh.getHost() === result.host
+          );
+          if (hostSsh) {
+            const hostAuditLogger = createServerAuditLogger(
+              hostSsh,
+              config.project,
+            );
+            await hostAuditLogger.logEngineInstall(
+              config.builder.engine,
+              result.success ? "success" : "failed",
+              result.message ||
+                (result.success ? "Installation successful" : result.error),
+            );
           }
         }
 
-        // Log successful initialization completion to connected servers
-        const auditResults = await auditLogger.logInitSuccess(
-          targetHosts,
-          config.builder.engine,
-        );
+        const failedInstalls = installResults.filter((r) => !r.success).length;
 
-        // Report successful audit logging (should match connected hosts)
-        const successfulHosts = auditResults
-          .filter((result) => result.success)
-          .map((result) => result.host);
+        if (failedInstalls > 0) {
+          const msg =
+            `${engineCommand} installation failed on ${failedInstalls} host(s)`;
+          installTracker.finish(false);
+          throw new Error(msg);
+        }
 
-        log.success(
-          `Initialization completed successfully on ${targetHosts.length} server(s)`,
-          "init",
-        );
-        log.info(
-          `Audit trail updated on ${successfulHosts.length} server(s): ${
-            successfulHosts.join(", ")
-          }`,
-          "audit",
-        );
-      });
+        installTracker.finish();
+      } catch (error) {
+        const errorMessage = error instanceof Error
+          ? error.message
+          : String(error);
+
+        // Log engine installation failure
+        for (const host of targetHosts) {
+          const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
+          if (hostSsh) {
+            const hostLogger = createServerAuditLogger(
+              hostSsh,
+              config.project,
+            );
+            await hostLogger.logEngineInstall(
+              config.builder.engine,
+              "failed",
+              errorMessage,
+            );
+          }
+        }
+
+        throw error;
+      }
+
+      // Network setup (if enabled)
+      if (config.network.enabled) {
+        try {
+          const networkResults = await setupNetwork(config, sshManagers);
+
+          // Log network setup results
+          const successfulSetups = networkResults.filter((r) => r.success);
+          const failedSetups = networkResults.filter((r) => !r.success);
+
+          if (failedSetups.length > 0) {
+            for (const result of failedSetups) {
+              log.error(
+                `${result.host}: ${result.error || "Unknown error"}`,
+                "network",
+              );
+            }
+
+            // Throw error for critical network component failures
+            const criticalErrors = failedSetups.map((r) =>
+              `${r.host}: ${r.error || "Network setup failed"}`
+            ).join("; ");
+            throw new Error(
+              `Critical network setup failures: ${criticalErrors}`,
+            );
+          }
+
+          // Log network setup to audit trail
+          for (const result of networkResults) {
+            const hostSsh = sshManagers.find((ssh) =>
+              ssh.getHost() === result.host
+            );
+            if (hostSsh) {
+              const hostLogger = createServerAuditLogger(
+                hostSsh,
+                config.project,
+              );
+              await hostLogger.logCustomCommand(
+                "network_setup",
+                result.success ? "success" : "failed",
+                result.message || result.error,
+              );
+            }
+          }
+
+          if (successfulSetups.length > 0) {
+            log.say(
+              `Private network configured on ${successfulSetups.length} server(s)`,
+            );
+          }
+        } catch (error) {
+          const errorMessage = error instanceof Error
+            ? error.message
+            : String(error);
+
+          // Log network setup failure
+          for (const host of targetHosts) {
+            const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
+            if (hostSsh) {
+              const hostLogger = createServerAuditLogger(
+                hostSsh,
+                config.project,
+              );
+              await hostLogger.logCustomCommand(
+                "network_setup",
+                "failed",
+                errorMessage,
+              );
+            }
+          }
+
+          throw error;
+        }
+      }
+
+      // Log successful initialization completion to connected servers
+      const auditResults = await auditLogger.logInitSuccess(
+        targetHosts,
+        config.builder.engine,
+      );
+
+      // Report successful audit logging (should match connected hosts)
+      const successfulHosts = auditResults
+        .filter((result) => result.success)
+        .map((result) => result.host);
+
+      console.log();
+      log.say(
+        `Initialization completed successfully on ${targetHosts.length} server(s)`,
+      );
+      log.say(
+        `Audit trail updated on ${successfulHosts.length} server(s): ${
+          successfulHosts.join(", ")
+        }`,
+        1,
+      );
     } catch (error) {
       await handleCommandError(error, {
         operation: "Initialization",
@@ -271,11 +247,11 @@ export const initCommand = new Command()
               .map((result) => result.host);
 
             if (successfulFailureLogs.length > 0) {
-              log.info(
+              log.say(
                 `Failure logged to ${successfulFailureLogs.length} server(s): ${
                   successfulFailureLogs.join(", ")
                 }`,
-                "audit",
+                1,
               );
             }
           }

--- a/src/commands/server/teardown.ts
+++ b/src/commands/server/teardown.ts
@@ -16,7 +16,7 @@ import {
   setupCommandContext,
 } from "../../utils/command_helpers.ts";
 import { handleCommandError } from "../../utils/error_handler.ts";
-import { log, Logger } from "../../utils/logger.ts";
+import { log } from "../../utils/logger.ts";
 import { createServerAuditLogger } from "../../utils/audit.ts";
 import { unregisterContainerFromNetwork } from "../../lib/services/container_registry.ts";
 import { loadTopology } from "../../lib/network/topology.ts";
@@ -27,7 +27,6 @@ import {
 import { stopCorrosionService } from "../../lib/network/corrosion.ts";
 import { stopCoreDNSService } from "../../lib/network/dns.ts";
 import { ProxyCommands } from "../../utils/proxy.ts";
-import { DEFAULT_MAX_PREFIX_LENGTH } from "../../constants.ts";
 import type { GlobalOptions } from "../../types.ts";
 
 export const teardownCommand = new Command()
@@ -38,417 +37,420 @@ export const teardownCommand = new Command()
     let ctx: Awaited<ReturnType<typeof setupCommandContext>> | undefined;
 
     try {
-      await log.group("Server Teardown", async () => {
-        // Set up command context
-        ctx = await setupCommandContext(globalOptions);
-        const { config, sshManagers, targetHosts } = ctx;
+      log.section("Server Teardown");
 
-        // Get confirmation unless --confirmed flag is passed
-        const confirmed = options.confirmed as boolean;
-        if (!confirmed) {
-          console.log();
-          log.warn(
-            "DESTRUCTIVE OPERATION - This will:",
-            "teardown",
-          );
-          log.warn(
-            `  Stop and remove ALL containers on ${targetHosts.length} server(s)`,
-            "teardown",
-          );
-          log.warn(
-            `  Purge the ${config.builder.engine} system (all images, volumes, networks)`,
-            "teardown",
-          );
-          log.warn(
-            `  Remove the ${config.builder.engine} container engine`,
-            "teardown",
-          );
-          if (config.network.enabled) {
-            log.warn(
-              "  Tear down the private network (WireGuard, Corrosion, CoreDNS)",
-              "teardown",
-            );
-          }
-          log.warn(
-            `  Remove .jiji/${config.project} directory`,
-            "teardown",
-          );
-          console.log();
+      // Set up command context
+      ctx = await setupCommandContext(globalOptions);
+      const { config, sshManagers, targetHosts } = ctx;
 
-          const confirm = await Confirm.prompt({
-            message: "Are you absolutely sure you want to proceed?",
-            default: false,
-          });
-
-          if (!confirm) {
-            log.info("Teardown cancelled by user", "teardown");
-            return;
-          }
-        }
-
-        log.info("Starting server teardown process...", "teardown");
-
-        // Create audit logger
-        const auditLogger = createServerAuditLogger(
-          sshManagers,
-          config.project,
+      // Get confirmation unless --confirmed flag is passed
+      const confirmed = options.confirmed as boolean;
+      if (!confirmed) {
+        console.log();
+        log.warn("DESTRUCTIVE OPERATION - This will:");
+        log.say(
+          `Stop and remove ALL containers on ${targetHosts.length} server(s)`,
+          1,
         );
-
-        // Log teardown start
-        await auditLogger.logCustomCommand(
-          "server_teardown",
-          "started",
-          `Starting complete server teardown on ${targetHosts.length} host(s)`,
+        log.say(
+          `Purge the ${config.builder.engine} system (all images, volumes, networks)`,
+          1,
         );
-
-        // Create server loggers for individual host reporting
-        const serverLoggers = Logger.forServers(targetHosts, {
-          maxPrefixLength: DEFAULT_MAX_PREFIX_LENGTH,
-        });
-
-        // Remove all services and containers
-        await log.group("Removing Services", async () => {
-          const services = Array.from(config.services.values());
-
-          for (const service of services) {
-            log.status(`Removing service: ${service.name}`, "teardown");
-
-            for (const server of service.servers) {
-              const host = server.host;
-              if (!targetHosts.includes(host)) {
-                log.warn(
-                  `Skipping ${service.name} on unreachable host: ${host}`,
-                  "teardown",
-                );
-                continue;
-              }
-
-              const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
-              if (!hostSsh) continue;
-
-              const serverLogger = serverLoggers.get(host)!;
-
-              try {
-                const containerName = service.getContainerName();
-
-                // Remove service from proxy if proxy is configured
-                if (service.proxy?.enabled) {
-                  try {
-                    const proxyCmd = new ProxyCommands(
-                      config.builder.engine,
-                      hostSsh,
-                    );
-                    await proxyCmd.remove(service.name);
-                    serverLogger.info(`Removed ${service.name} from proxy`);
-                  } catch (error) {
-                    serverLogger.warn(
-                      `Failed to remove from proxy: ${error}`,
-                    );
-                  }
-                }
-
-                // Unregister from network (if enabled)
-                if (config.network.enabled) {
-                  try {
-                    await unregisterContainerFromNetwork(
-                      hostSsh,
-                      containerName,
-                      service.name,
-                      config.project,
-                    );
-                    serverLogger.info(
-                      `Unregistered ${service.name} from network`,
-                    );
-                  } catch (error) {
-                    serverLogger.warn(
-                      `Failed to unregister from network: ${error}`,
-                    );
-                  }
-                }
-
-                // Stop and remove the container
-                await executeBestEffort(
-                  hostSsh,
-                  `${config.builder.engine} rm -f ${containerName}`,
-                  `removing container ${containerName}`,
-                );
-                serverLogger.success(`Removed container ${containerName}`);
-
-                // Remove named volumes
-                const namedVolumes = service.getNamedVolumes();
-                for (const volumeName of namedVolumes) {
-                  await executeBestEffort(
-                    hostSsh,
-                    `${config.builder.engine} volume rm ${volumeName}`,
-                    `removing volume ${volumeName}`,
-                  );
-                  serverLogger.info(`Removed volume ${volumeName}`);
-                }
-              } catch (error) {
-                serverLogger.error(
-                  `Failed to remove ${service.name}: ${error}`,
-                );
-              }
-            }
-          }
-
-          log.success("All services removed", "teardown");
-        });
-
-        // Purge container engine system
-        await log.group(
-          "Purging Container Engine System",
-          async () => {
-            for (const host of targetHosts) {
-              const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
-              if (!hostSsh) continue;
-
-              const serverLogger = serverLoggers.get(host)!;
-
-              try {
-                serverLogger.info("Stopping all containers...");
-                await executeBestEffort(
-                  hostSsh,
-                  `${config.builder.engine} stop $(${config.builder.engine} ps -aq)`,
-                  "stopping containers",
-                );
-
-                serverLogger.info("Removing all containers...");
-                await executeBestEffort(
-                  hostSsh,
-                  `${config.builder.engine} rm -f $(${config.builder.engine} ps -aq)`,
-                  "removing containers",
-                );
-
-                serverLogger.info("Removing all images...");
-                await executeBestEffort(
-                  hostSsh,
-                  `${config.builder.engine} rmi -f $(${config.builder.engine} images -aq)`,
-                  "removing images",
-                );
-
-                serverLogger.info("Removing all volumes...");
-                await executeBestEffort(
-                  hostSsh,
-                  `${config.builder.engine} volume rm $(${config.builder.engine} volume ls -q)`,
-                  "removing volumes",
-                );
-
-                serverLogger.info("Removing all networks...");
-                await executeBestEffort(
-                  hostSsh,
-                  `${config.builder.engine} network prune -f`,
-                  "pruning networks",
-                );
-
-                serverLogger.info("Running system prune...");
-                await executeBestEffort(
-                  hostSsh,
-                  `${config.builder.engine} system prune -a -f --volumes`,
-                  "system prune",
-                );
-
-                serverLogger.success("Container engine system purged");
-              } catch (error) {
-                serverLogger.error(`System purge failed: ${error}`);
-              }
-            }
-
-            log.success(
-              "Container engine system purged on all hosts",
-              "teardown",
-            );
-          },
+        log.say(
+          `Remove the ${config.builder.engine} container engine`,
+          1,
         );
-
-        // Remove container engine
-        await log.group("Removing Container Engine", async () => {
-          for (const host of targetHosts) {
-            const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
-            if (!hostSsh) continue;
-
-            const serverLogger = serverLoggers.get(host)!;
-
-            try {
-              const engine = config.builder.engine;
-
-              if (engine === "docker") {
-                serverLogger.info("Stopping Docker service...");
-                await executeBestEffort(
-                  hostSsh,
-                  "systemctl stop docker.socket docker.service",
-                  "stopping Docker service",
-                );
-
-                serverLogger.info("Removing Docker packages...");
-                await executeBestEffort(
-                  hostSsh,
-                  "apt-get remove -y docker.io docker-compose",
-                  "removing Docker packages",
-                );
-                await executeBestEffort(
-                  hostSsh,
-                  "apt-get autoremove -y",
-                  "autoremove packages",
-                );
-
-                serverLogger.info("Removing Docker files...");
-                await executeBestEffort(
-                  hostSsh,
-                  "rm -rf /var/lib/docker",
-                  "removing Docker data",
-                );
-                await executeBestEffort(
-                  hostSsh,
-                  "rm -rf /etc/docker",
-                  "removing Docker config",
-                );
-              } else if (engine === "podman") {
-                serverLogger.info("Removing Podman packages...");
-                await executeBestEffort(
-                  hostSsh,
-                  "apt-get remove -y podman",
-                  "removing Podman packages",
-                );
-                await executeBestEffort(
-                  hostSsh,
-                  "apt-get autoremove -y",
-                  "autoremove packages",
-                );
-
-                serverLogger.info("Removing Podman files...");
-                await executeBestEffort(
-                  hostSsh,
-                  "rm -rf /var/lib/containers",
-                  "removing Podman data",
-                );
-                await executeBestEffort(
-                  hostSsh,
-                  "rm -rf /etc/containers",
-                  "removing Podman config",
-                );
-              }
-
-              serverLogger.success(`${engine} removed`);
-            } catch (error) {
-              serverLogger.error(`Engine removal failed: ${error}`);
-            }
-          }
-
-          log.success("Container engine removed from all hosts", "teardown");
-        });
-
-        // Tear down network
         if (config.network.enabled) {
-          await log.group("Tearing Down Network", async () => {
-            // Try to load topology
-            let topology = null;
-            for (const ssh of sshManagers) {
-              try {
-                topology = await loadTopology(ssh);
-                if (topology) break;
-              } catch {
-                continue;
-              }
-            }
-
-            if (!topology) {
-              log.info(
-                "No network cluster found, skipping network teardown",
-                "network",
-              );
-            } else {
-              log.info(
-                `Tearing down network on ${topology.servers.length} server(s)`,
-                "network",
-              );
-
-              for (const server of topology.servers) {
-                const ssh = sshManagers.find((s) =>
-                  s.getHost() === server.hostname
-                );
-                const serverLogger = serverLoggers.get(server.hostname)!;
-
-                if (!ssh) {
-                  serverLogger.warn("SSH connection not available, skipping");
-                  continue;
-                }
-
-                try {
-                  serverLogger.info("Stopping DNS service...");
-                  await stopCoreDNSService(ssh);
-
-                  if (topology.discovery === "corrosion") {
-                    serverLogger.info("Stopping Corrosion service...");
-                    await stopCorrosionService(ssh);
-                  }
-
-                  serverLogger.info("Stopping WireGuard interface...");
-                  await bringDownWireGuardInterface(ssh);
-                  await disableWireGuardService(ssh);
-
-                  serverLogger.info("Removing network configuration files...");
-                  await ssh.executeCommand("rm -f /etc/wireguard/jiji0.conf");
-                  await ssh.executeCommand("rm -rf /opt/jiji/corrosion");
-                  await ssh.executeCommand("rm -rf /opt/jiji/dns");
-                  await ssh.executeCommand(
-                    "rm -f /etc/systemd/system/jiji-corrosion.service",
-                  );
-                  await ssh.executeCommand(
-                    "rm -f /etc/systemd/system/jiji-dns.service",
-                  );
-                  await ssh.executeCommand(
-                    "rm -f /etc/systemd/system/jiji-dns-update.service",
-                  );
-                  await ssh.executeCommand(
-                    "rm -f /etc/systemd/system/jiji-dns-update.timer",
-                  );
-                  await ssh.executeCommand(
-                    "rm -f /etc/systemd/system/jiji-control-loop.service",
-                  );
-                  await ssh.executeCommand("systemctl daemon-reload");
-
-                  serverLogger.success("Network teardown complete");
-                } catch (error) {
-                  serverLogger.error(`Network teardown failed: ${error}`);
-                }
-              }
-
-              log.success("Network teardown complete on all hosts", "network");
-            }
-          });
+          log.say(
+            "Tear down the private network (WireGuard, Corrosion, CoreDNS)",
+            1,
+          );
         }
+        log.say(
+          `Remove .jiji/${config.project} directory`,
+          1,
+        );
+        console.log();
 
-        // Remove project directory
-        await log.group("Removing Project Directory", async () => {
-          const projectDir = `.jiji/${config.project}`;
-
-          for (const host of targetHosts) {
-            const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
-            if (!hostSsh) continue;
-
-            const serverLogger = serverLoggers.get(host)!;
-
-            try {
-              await hostSsh.executeCommand(`rm -rf ${projectDir}`);
-              serverLogger.success(`Removed ${projectDir}`);
-            } catch (error) {
-              serverLogger.error(`Failed to remove ${projectDir}: ${error}`);
-            }
-          }
-
-          log.success(`Project directory removed from all hosts`, "teardown");
+        const confirm = await Confirm.prompt({
+          message: "Are you absolutely sure you want to proceed?",
+          default: false,
         });
 
-        // Log teardown completion
-        await auditLogger.logCustomCommand(
-          "server_teardown",
-          "success",
-          `Server teardown completed successfully on ${targetHosts.length} host(s)`,
-        );
+        if (!confirm) {
+          log.say("Teardown cancelled by user");
+          return;
+        }
+      }
 
-        log.success("Server teardown completed successfully", "teardown");
-      });
+      log.say("Starting server teardown process...");
+
+      // Create audit logger
+      const auditLogger = createServerAuditLogger(
+        sshManagers,
+        config.project,
+      );
+
+      // Log teardown start
+      await auditLogger.logCustomCommand(
+        "server_teardown",
+        "started",
+        `Starting complete server teardown on ${targetHosts.length} host(s)`,
+      );
+
+      // Remove all services and containers
+      const removeTracker = log.createStepTracker("Removing Services");
+
+      const services = Array.from(config.services.values());
+
+      for (const service of services) {
+        removeTracker.step(`Removing service: ${service.name}`);
+
+        for (const server of service.servers) {
+          const host = server.host;
+          if (!targetHosts.includes(host)) {
+            continue;
+          }
+
+          const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
+          if (!hostSsh) continue;
+
+          try {
+            const containerName = service.getContainerName();
+
+            // Remove service from proxy if proxy is configured
+            if (service.proxy?.enabled) {
+              try {
+                const proxyCmd = new ProxyCommands(
+                  config.builder.engine,
+                  hostSsh,
+                );
+                await proxyCmd.remove(service.name);
+                removeTracker.remote(
+                  host,
+                  `Removed ${service.name} from proxy`,
+                  { indent: 1 },
+                );
+              } catch (_error) {
+                // Best effort
+              }
+            }
+
+            // Unregister from network (if enabled)
+            if (config.network.enabled) {
+              try {
+                await unregisterContainerFromNetwork(
+                  hostSsh,
+                  containerName,
+                  service.name,
+                  config.project,
+                );
+                removeTracker.remote(
+                  host,
+                  `Unregistered ${service.name} from network`,
+                  { indent: 1 },
+                );
+              } catch (_error) {
+                // Best effort
+              }
+            }
+
+            // Stop and remove the container
+            await executeBestEffort(
+              hostSsh,
+              `${config.builder.engine} rm -f ${containerName}`,
+              `removing container ${containerName}`,
+            );
+            removeTracker.remote(
+              host,
+              `Removed container ${containerName}`,
+              { indent: 1 },
+            );
+
+            // Remove named volumes
+            const namedVolumes = service.getNamedVolumes();
+            for (const volumeName of namedVolumes) {
+              await executeBestEffort(
+                hostSsh,
+                `${config.builder.engine} volume rm ${volumeName}`,
+                `removing volume ${volumeName}`,
+              );
+              removeTracker.remote(
+                host,
+                `Removed volume ${volumeName}`,
+                { indent: 1 },
+              );
+            }
+          } catch (error) {
+            removeTracker.remote(
+              host,
+              `Failed to remove ${service.name}: ${error}`,
+              { indent: 1 },
+            );
+          }
+        }
+      }
+
+      removeTracker.finish();
+
+      // Purge container engine system
+      const purgeTracker = log.createStepTracker(
+        "Purging Container Engine System",
+      );
+
+      for (const host of targetHosts) {
+        const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
+        if (!hostSsh) continue;
+
+        try {
+          purgeTracker.remote(host, "Stopping all containers...");
+          await executeBestEffort(
+            hostSsh,
+            `${config.builder.engine} stop $(${config.builder.engine} ps -aq)`,
+            "stopping containers",
+          );
+
+          purgeTracker.remote(host, "Removing all containers...");
+          await executeBestEffort(
+            hostSsh,
+            `${config.builder.engine} rm -f $(${config.builder.engine} ps -aq)`,
+            "removing containers",
+          );
+
+          purgeTracker.remote(host, "Removing all images...");
+          await executeBestEffort(
+            hostSsh,
+            `${config.builder.engine} rmi -f $(${config.builder.engine} images -aq)`,
+            "removing images",
+          );
+
+          purgeTracker.remote(host, "Removing all volumes...");
+          await executeBestEffort(
+            hostSsh,
+            `${config.builder.engine} volume rm $(${config.builder.engine} volume ls -q)`,
+            "removing volumes",
+          );
+
+          purgeTracker.remote(host, "Removing all networks...");
+          await executeBestEffort(
+            hostSsh,
+            `${config.builder.engine} network prune -f`,
+            "pruning networks",
+          );
+
+          purgeTracker.remote(host, "Running system prune...");
+          await executeBestEffort(
+            hostSsh,
+            `${config.builder.engine} system prune -a -f --volumes`,
+            "system prune",
+          );
+
+          purgeTracker.remote(host, "Container engine system purged");
+        } catch (error) {
+          purgeTracker.remote(host, `System purge failed: ${error}`);
+        }
+      }
+
+      purgeTracker.finish();
+
+      // Remove container engine
+      const engineTracker = log.createStepTracker(
+        "Removing Container Engine",
+      );
+
+      for (const host of targetHosts) {
+        const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
+        if (!hostSsh) continue;
+
+        try {
+          const engine = config.builder.engine;
+
+          if (engine === "docker") {
+            engineTracker.remote(host, "Removing Docker packages...");
+            await executeBestEffort(
+              hostSsh,
+              "systemctl stop docker.socket docker.service",
+              "stopping Docker service",
+            );
+            await executeBestEffort(
+              hostSsh,
+              "apt-get remove -y docker.io docker-compose",
+              "removing Docker packages",
+            );
+            await executeBestEffort(
+              hostSsh,
+              "apt-get autoremove -y",
+              "autoremove packages",
+            );
+
+            engineTracker.remote(host, "Removing Docker files...");
+            await executeBestEffort(
+              hostSsh,
+              "rm -rf /var/lib/docker",
+              "removing Docker data",
+            );
+            await executeBestEffort(
+              hostSsh,
+              "rm -rf /etc/docker",
+              "removing Docker config",
+            );
+          } else if (engine === "podman") {
+            engineTracker.remote(host, "Removing Podman packages...");
+            await executeBestEffort(
+              hostSsh,
+              "apt-get remove -y podman",
+              "removing Podman packages",
+            );
+            await executeBestEffort(
+              hostSsh,
+              "apt-get autoremove -y",
+              "autoremove packages",
+            );
+
+            engineTracker.remote(host, "Removing Podman files...");
+            await executeBestEffort(
+              hostSsh,
+              "rm -rf /var/lib/containers",
+              "removing Podman data",
+            );
+            await executeBestEffort(
+              hostSsh,
+              "rm -rf /etc/containers",
+              "removing Podman config",
+            );
+          }
+
+          engineTracker.remote(host, `${engine} removed`);
+        } catch (error) {
+          engineTracker.remote(host, `Engine removal failed: ${error}`);
+        }
+      }
+
+      engineTracker.finish();
+
+      // Tear down network
+      if (config.network.enabled) {
+        const networkTracker = log.createStepTracker("Tearing Down Network");
+
+        // Try to load topology
+        let topology = null;
+        for (const ssh of sshManagers) {
+          try {
+            topology = await loadTopology(ssh);
+            if (topology) break;
+          } catch {
+            continue;
+          }
+        }
+
+        if (!topology) {
+          networkTracker.step("No network cluster found, skipping");
+        } else {
+          networkTracker.step(
+            `Tearing down network on ${topology.servers.length} server(s)`,
+          );
+
+          for (const server of topology.servers) {
+            const ssh = sshManagers.find((s) =>
+              s.getHost() === server.hostname
+            );
+
+            if (!ssh) {
+              continue;
+            }
+
+            try {
+              networkTracker.remote(server.hostname, "Stopping DNS service...");
+              await stopCoreDNSService(ssh);
+
+              if (topology.discovery === "corrosion") {
+                networkTracker.remote(
+                  server.hostname,
+                  "Stopping Corrosion service...",
+                );
+                await stopCorrosionService(ssh);
+              }
+
+              networkTracker.remote(
+                server.hostname,
+                "Stopping WireGuard interface...",
+              );
+              await bringDownWireGuardInterface(ssh);
+              await disableWireGuardService(ssh);
+
+              networkTracker.remote(
+                server.hostname,
+                "Removing network configuration files...",
+              );
+              await ssh.executeCommand("rm -f /etc/wireguard/jiji0.conf");
+              await ssh.executeCommand("rm -rf /opt/jiji/corrosion");
+              await ssh.executeCommand("rm -rf /opt/jiji/dns");
+              await ssh.executeCommand(
+                "rm -f /etc/systemd/system/jiji-corrosion.service",
+              );
+              await ssh.executeCommand(
+                "rm -f /etc/systemd/system/jiji-dns.service",
+              );
+              await ssh.executeCommand(
+                "rm -f /etc/systemd/system/jiji-dns-update.service",
+              );
+              await ssh.executeCommand(
+                "rm -f /etc/systemd/system/jiji-dns-update.timer",
+              );
+              await ssh.executeCommand(
+                "rm -f /etc/systemd/system/jiji-control-loop.service",
+              );
+              await ssh.executeCommand("systemctl daemon-reload");
+
+              networkTracker.remote(
+                server.hostname,
+                "Network teardown complete",
+              );
+            } catch (error) {
+              networkTracker.remote(
+                server.hostname,
+                `Network teardown failed: ${error}`,
+              );
+            }
+          }
+        }
+
+        networkTracker.finish();
+      }
+
+      // Remove project directory
+      const cleanupTracker = log.createStepTracker(
+        "Removing Project Directory",
+      );
+
+      const projectDir = `.jiji/${config.project}`;
+
+      for (const host of targetHosts) {
+        const hostSsh = sshManagers.find((ssh) => ssh.getHost() === host);
+        if (!hostSsh) continue;
+
+        try {
+          await hostSsh.executeCommand(`rm -rf ${projectDir}`);
+          cleanupTracker.remote(host, `Removed ${projectDir}`);
+        } catch (error) {
+          cleanupTracker.remote(
+            host,
+            `Failed to remove ${projectDir}: ${error}`,
+          );
+        }
+      }
+
+      cleanupTracker.finish();
+
+      // Log teardown completion
+      await auditLogger.logCustomCommand(
+        "server_teardown",
+        "success",
+        `Server teardown completed successfully on ${targetHosts.length} host(s)`,
+      );
+
+      console.log();
+      log.say("Server teardown completed successfully");
     } catch (error) {
       await handleCommandError(error, {
         operation: "Server teardown",

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -5,5 +5,5 @@ import { log } from "../utils/logger.ts";
 export const versionCommand = new Command()
   .description("Show jiji version")
   .action(() => {
-    log.info(VERSION, "version");
+    log.say(VERSION);
   });

--- a/src/lib/services/logs_service.ts
+++ b/src/lib/services/logs_service.ts
@@ -113,14 +113,14 @@ export class LogsService {
           result.stderr.includes("No such container") ||
           result.stderr.includes("No such object")
         ) {
-          log.warn(
-            `Container ${containerNameOrId} not found on ${host}`,
-            this.component,
-          );
+          log.hostOutput(host, `Container ${containerNameOrId} not found`, {
+            type: "Logs",
+          });
         } else {
-          log.error(
-            `Failed to fetch logs from ${containerNameOrId} on ${host}: ${result.stderr}`,
-            this.component,
+          log.hostOutput(
+            host,
+            `Failed to fetch logs: ${result.stderr}`,
+            { type: "Error" },
           );
         }
         return;
@@ -128,12 +128,10 @@ export class LogsService {
 
       const output = result.stdout.trim();
       if (output) {
-        console.log(output);
+        // Use host-grouped output pattern
+        log.hostOutput(host, output, { type: "Logs" });
       } else {
-        log.info(
-          `No logs found for ${containerNameOrId} on ${host}`,
-          this.component,
-        );
+        log.hostOutput(host, "No logs found", { type: "Logs" });
       }
     } catch (error) {
       log.error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,12 +12,16 @@ import { servicesCommand } from "./commands/services/index.ts";
 import { proxyCommand } from "./commands/proxy/index.ts";
 import { registryCommand } from "./commands/registry/index.ts";
 import { networkCommand } from "./commands/network.ts";
-import { setGlobalLogLevel } from "./utils/logger.ts";
+import { setGlobalLogLevel, setGlobalQuietMode } from "./utils/logger.ts";
 
 const command = new Command()
   .name("jiji")
   .description("Jiji - Infrastructure management tool")
   .globalOption("-v, --verbose", "Detailed logging")
+  .globalOption(
+    "-q, --quiet",
+    "Minimal output (suppress host headers and extra messages)",
+  )
   .globalOption(
     "--version=<VERSION:string>",
     "Run commands against a specific app version",
@@ -65,4 +69,13 @@ const options = await command.parse(Deno.args);
 // Set global log level based on --verbose flag
 if (options.options.verbose) {
   setGlobalLogLevel("debug");
+}
+
+// Set global quiet mode based on --quiet flag
+if (options.options.quiet) {
+  setGlobalQuietMode(true);
+  // In quiet mode, only show errors and warnings
+  if (!options.options.verbose) {
+    setGlobalLogLevel("warn");
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@
 export interface GlobalOptions {
   environment?: string;
   verbose?: boolean;
+  quiet?: boolean;
   version?: string;
   configFile?: string;
   hosts?: string;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -23,6 +23,7 @@ export interface LoggerOptions {
   maxPrefixLength?: number;
   colors?: boolean;
   minLevel?: LogLevel;
+  quiet?: boolean;
 }
 
 /**

--- a/src/utils/tests/config_test.ts
+++ b/src/utils/tests/config_test.ts
@@ -264,13 +264,8 @@ Deno.test("getAvailableConfigs - returns available configs", async () => {
   );
 
   try {
-    const originalCwd = Deno.cwd();
-    Deno.chdir(tempDir);
-
-    const configs = await getAvailableConfigs();
+    const configs = await getAvailableConfigs(tempDir);
     assertEquals(configs.length >= 3, true);
-
-    Deno.chdir(originalCwd);
   } finally {
     await Deno.remove(tempDir, { recursive: true });
   }

--- a/src/utils/tests/logger_test.ts
+++ b/src/utils/tests/logger_test.ts
@@ -32,10 +32,10 @@ Deno.test("Logger basic functionality", () => {
   logger.error("test error message");
 
   assertEquals(capturedLogs.length, 4);
-  assertStringIncludes(capturedLogs[0], "[INFO ]");
+  // Info and success no longer show level indicators
   assertStringIncludes(capturedLogs[0], "test info message");
-  assertStringIncludes(capturedLogs[1], "[SUCCESS]");
   assertStringIncludes(capturedLogs[1], "test success message");
+  // Warn and error still show level indicators
   assertStringIncludes(capturedLogs[2], "[WARN ]");
   assertStringIncludes(capturedLogs[2], "test warning message");
   assertStringIncludes(capturedLogs[3], "[ERROR]");
@@ -58,7 +58,7 @@ Deno.test("Logger with prefix", () => {
 
   assertEquals(capturedLogs.length, 1);
   assertStringIncludes(capturedLogs[0], "test-server");
-  assertStringIncludes(capturedLogs[0], "[INFO ]");
+  // Info no longer shows level indicator
   assertStringIncludes(capturedLogs[0], "test message");
 
   restoreConsole();


### PR DESCRIPTION
- Replaced disparate logging calls in logs/deploy with unified helpers: log.hostOutput and log.say
- Consolidated output formatting and host-specific messages for consistency across deployment logs
- Simplified logging code paths to improve maintainability and reduce duplication