### PR TITLE
Network resilience: tombstones, peer cache, split-brain heal, bridge recovery

### DIFF
--- a/packages/cli/src/commands/network.ts
+++ b/packages/cli/src/commands/network.ts
@@ -10,6 +10,7 @@ import { gcCommand } from "./network/gc.ts";
 import { dnsCommand } from "./network/dns.ts";
 import { inspectCommand } from "./network/inspect.ts";
 import { dbCommand } from "./network/db.ts";
+import { serverCommand } from "./network/server.ts";
 
 export const networkCommand = new Command()
   .description("Manage private network")
@@ -22,4 +23,5 @@ export const networkCommand = new Command()
   .command("gc", gcCommand)
   .command("dns", dnsCommand)
   .command("inspect", inspectCommand)
-  .command("db", dbCommand);
+  .command("db", dbCommand)
+  .command("server", serverCommand);

--- a/packages/cli/src/commands/network/server.ts
+++ b/packages/cli/src/commands/network/server.ts
@@ -1,0 +1,135 @@
+/**
+ * Network server commands — manage servers registered in the cluster.
+ *
+ * Currently only `remove` is implemented, which tombstones a server in
+ * Corrosion. Once the row gossips out, every node's daemon reconciler will
+ * drop the corresponding WireGuard peer on its next tick (~30s) and the
+ * garbage collector will prune any container records still referencing the
+ * dead server.
+ *
+ * `remove` is metadata-only: it does NOT SSH to the target server, stop
+ * services, or revoke keys. Use this AFTER a server is physically
+ * decommissioned, or alongside `jiji server teardown` for in-place cleanup.
+ */
+
+import { Command } from "@cliffy/command";
+import { Confirm } from "@cliffy/prompt";
+import {
+  cleanupSSHConnections,
+  displayCommandHeader,
+  setupCommandContext,
+} from "../../utils/command_helpers.ts";
+import { handleCommandError } from "../../utils/error_handler.ts";
+import { log } from "../../utils/logger.ts";
+import { tombstoneServer } from "../../lib/network/corrosion.ts";
+import { loadTopology } from "../../lib/network/topology.ts";
+import type { GlobalOptions } from "../../types.ts";
+
+const removeCommand = new Command()
+  .description("Tombstone a server in the cluster, removing it from the mesh")
+  .arguments("<id:string>")
+  .option("-y, --confirmed", "Skip confirmation prompt", { default: false })
+  .action(async (options, id) => {
+    const globalOptions = options as unknown as GlobalOptions;
+    let ctx: Awaited<ReturnType<typeof setupCommandContext>> | undefined;
+
+    try {
+      ctx = await setupCommandContext(globalOptions, {
+        useAllDefinedServers: true,
+      });
+      const { config, sshManagers } = ctx;
+
+      displayCommandHeader("Network Server Remove:", config, sshManagers);
+
+      if (!config.network.enabled) {
+        log.error(
+          "Network is not enabled in configuration. Tombstones only apply to clusters with network.enabled: true.",
+        );
+        Deno.exit(1);
+      }
+
+      // We only need one reachable cluster member; Corrosion is distributed.
+      const writer = sshManagers[0];
+      if (!writer) {
+        log.error(
+          "No SSH connections available. At least one cluster member must be reachable to write the tombstone.",
+        );
+        Deno.exit(1);
+      }
+
+      // Show a hint about what we're about to remove if we can resolve it.
+      let hostnameHint = "";
+      try {
+        const topology = await loadTopology(writer);
+        const match = topology?.servers.find((s) => s.id === id);
+        if (match) {
+          hostnameHint = ` (${match.hostname})`;
+        }
+      } catch {
+        // Topology lookup is informational only.
+      }
+
+      const confirmed = options.confirmed as boolean;
+      if (!confirmed) {
+        console.log();
+        log.warn(`This will tombstone server '${id}'${hostnameHint}.`);
+        log.say(
+          "Every node will drop its WireGuard peer for this server on the next daemon tick,",
+          1,
+        );
+        log.say(
+          "and any container records pointing at it will be garbage-collected.",
+          1,
+        );
+        console.log();
+
+        const ok = await Confirm.prompt({
+          message: `Tombstone ${id}?`,
+          default: false,
+        });
+        if (!ok) {
+          log.say("Cancelled by user");
+          return;
+        }
+      }
+
+      const result = await tombstoneServer(writer, id);
+
+      if (!result.tombstoned) {
+        log.error(
+          `Server '${id}' not found in Corrosion. Run \`jiji network status\` to list known server ids.`,
+        );
+        Deno.exit(1);
+      }
+
+      if (result.alreadyRemoved) {
+        log.say(`Server '${id}' was already tombstoned — no change.`);
+        return;
+      }
+
+      log.success(`\nServer '${id}'${hostnameHint} tombstoned.`);
+      log.say(
+        "Peers will be removed and containers GC'd within ~30s on each node.",
+        1,
+      );
+    } catch (error) {
+      await handleCommandError(error, {
+        operation: "Network server remove",
+        component: "network-server-remove",
+        sshManagers: ctx?.sshManagers,
+        projectName: ctx?.config?.project,
+        targetHosts: ctx?.targetHosts,
+      });
+    } finally {
+      if (ctx?.sshManagers) {
+        cleanupSSHConnections(ctx.sshManagers);
+      }
+    }
+  });
+
+export const serverCommand = new Command()
+  .description("Manage servers registered in the cluster")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("remove", removeCommand);

--- a/packages/cli/src/lib/network/corrosion.ts
+++ b/packages/cli/src/lib/network/corrosion.ts
@@ -69,7 +69,11 @@ CREATE TABLE IF NOT EXISTS cluster_metadata (
   value TEXT NOT NULL DEFAULT ''
 );
 
--- Servers in the cluster
+-- Servers in the cluster.
+-- removed_at: NULL = active. Non-null = decommissioned at that wall-clock
+-- millis. Set via "jiji network remove <id>"; never set automatically. The
+-- daemon reconciler treats a non-null tombstone as a positive signal to drop
+-- the corresponding WireGuard peer cluster-wide.
 CREATE TABLE IF NOT EXISTS servers (
   id TEXT NOT NULL PRIMARY KEY,
   hostname TEXT NOT NULL DEFAULT '',
@@ -78,7 +82,8 @@ CREATE TABLE IF NOT EXISTS servers (
   wireguard_pubkey TEXT NOT NULL DEFAULT '',
   management_ip TEXT NOT NULL DEFAULT '',
   endpoints TEXT NOT NULL DEFAULT '',
-  last_seen INTEGER NOT NULL DEFAULT 0
+  last_seen INTEGER NOT NULL DEFAULT 0,
+  removed_at INTEGER DEFAULT NULL
 );
 
 -- Services deployed
@@ -178,6 +183,38 @@ export async function applyMigrations(ssh: SSHManager): Promise<boolean> {
       log.success(`Migration complete on ${host}`, "corrosion");
     } else {
       log.debug(`Migration already applied on ${host}`, "corrosion");
+    }
+
+    // Independent check: servers.removed_at (tombstone column)
+    const removedAtCheck = await corrosionQuery(
+      ssh,
+      "SELECT COUNT(*) FROM pragma_table_info('servers') WHERE name = 'removed_at';",
+    );
+
+    if (removedAtCheck.code === 0 && removedAtCheck.stdout.trim() === "0") {
+      log.info(
+        `Applying servers.removed_at migration on ${host}...`,
+        "corrosion",
+      );
+      const result = await corrosionExec(
+        ssh,
+        "ALTER TABLE servers ADD COLUMN removed_at INTEGER DEFAULT NULL;",
+      );
+      if (
+        result.code !== 0 &&
+        !result.stderr.includes("duplicate column") &&
+        !result.stderr.includes("already exists")
+      ) {
+        log.warn(
+          `removed_at migration failed: ${result.stderr}`,
+          "corrosion",
+        );
+      } else {
+        log.success(
+          `servers.removed_at migration complete on ${host}`,
+          "corrosion",
+        );
+      }
     }
 
     return true;
@@ -431,14 +468,63 @@ export async function registerServer(
 ): Promise<void> {
   const endpointsJson = JSON.stringify(server.endpoints);
 
+  // UPSERT preserves removed_at so a re-registration (e.g. another `jiji
+  // network setup` run) doesn't silently un-tombstone a decommissioned server.
+  // Use `jiji server restore <id>` (TODO) if you actually want to revive one.
   const query =
-    sql`INSERT OR REPLACE INTO servers (id, hostname, subnet, wireguard_ip, wireguard_pubkey, management_ip, endpoints, last_seen) VALUES (${server.id}, ${server.hostname}, ${server.subnet}, ${server.wireguardIp}, ${server.wireguardPublicKey}, ${server.managementIp}, ${endpointsJson}, ${server.lastSeen});`;
+    sql`INSERT INTO servers (id, hostname, subnet, wireguard_ip, wireguard_pubkey, management_ip, endpoints, last_seen) VALUES (${server.id}, ${server.hostname}, ${server.subnet}, ${server.wireguardIp}, ${server.wireguardPublicKey}, ${server.managementIp}, ${endpointsJson}, ${server.lastSeen}) ON CONFLICT(id) DO UPDATE SET hostname = excluded.hostname, subnet = excluded.subnet, wireguard_ip = excluded.wireguard_ip, wireguard_pubkey = excluded.wireguard_pubkey, management_ip = excluded.management_ip, endpoints = excluded.endpoints, last_seen = excluded.last_seen;`;
 
   const result = await corrosionExec(ssh, query);
 
   if (result.code !== 0) {
     throw new Error(`Failed to register server: ${result.stderr}`);
   }
+}
+
+/**
+ * Tombstone a server by id, signalling cluster-wide that its WireGuard peer
+ * should be removed and its containers GC'd.
+ *
+ * Returns true if the row was tombstoned (or already tombstoned), false if no
+ * such id exists. Idempotent: re-tombstoning is a no-op and does not overwrite
+ * the original removed_at timestamp.
+ */
+export async function tombstoneServer(
+  ssh: SSHManager,
+  serverId: string,
+): Promise<{ tombstoned: boolean; alreadyRemoved: boolean }> {
+  // IFNULL coalesces to 0 so we can distinguish "no row" (empty stdout) from
+  // "row exists, removed_at is NULL" (stdout has the id and a 0).
+  const existing = await corrosionQuery(
+    ssh,
+    sql`SELECT id, IFNULL(removed_at, 0) FROM servers WHERE id = ${serverId};`,
+  );
+
+  if (existing.code !== 0) {
+    throw new Error(`Failed to look up server: ${existing.stderr}`);
+  }
+
+  const line = existing.stdout.trim();
+  if (line.length === 0) {
+    return { tombstoned: false, alreadyRemoved: false };
+  }
+
+  const removedAtStr = line.split("|")[1] ?? "0";
+  if (removedAtStr !== "0") {
+    return { tombstoned: true, alreadyRemoved: true };
+  }
+
+  const now = Date.now();
+  const result = await corrosionExec(
+    ssh,
+    sql`UPDATE servers SET removed_at = ${now} WHERE id = ${serverId} AND removed_at IS NULL;`,
+  );
+
+  if (result.code !== 0) {
+    throw new Error(`Failed to tombstone server: ${result.stderr}`);
+  }
+
+  return { tombstoned: true, alreadyRemoved: false };
 }
 
 /**
@@ -790,6 +876,7 @@ export async function queryActiveServers(
            management_ip, endpoints, last_seen
     FROM servers
     WHERE last_seen > (strftime('%s', 'now') - 300) * 1000
+      AND removed_at IS NULL
     ORDER BY hostname;
   `;
 
@@ -809,16 +896,23 @@ export async function queryActiveServers(
 /**
  * Query all servers from Corrosion (including inactive ones)
  *
+ * Tombstoned (decommissioned) servers are excluded by default. Pass
+ * `includeRemoved: true` for admin/diagnostic views that need every row.
+ *
  * @param ssh - SSH connection to any server
- * @returns Array of all server registrations
+ * @param options.includeRemoved - Include tombstoned servers (default: false)
+ * @returns Array of server registrations
  */
 export async function queryAllServers(
   ssh: SSHManager,
+  options: { includeRemoved?: boolean } = {},
 ): Promise<ServerRegistration[]> {
+  const where = options.includeRemoved ? "" : "WHERE removed_at IS NULL";
   const sql = `
     SELECT id, hostname, subnet, wireguard_ip, wireguard_pubkey,
            management_ip, endpoints, last_seen
     FROM servers
+    ${where}
     ORDER BY hostname;
   `;
 
@@ -1018,6 +1112,7 @@ export async function queryOfflineServers(
            (SELECT COUNT(*) FROM containers c WHERE c.server_id = s.id) as container_count
     FROM servers s
     WHERE s.last_seen < ${threshold}
+      AND s.removed_at IS NULL
     ORDER BY s.last_seen;
   `;
 
@@ -1236,8 +1331,8 @@ export async function getDbStats(ssh: SSHManager): Promise<DbStats> {
 
   const sql = `
     SELECT
-      (SELECT COUNT(*) FROM servers) as server_count,
-      (SELECT COUNT(*) FROM servers WHERE last_seen > ${activeThreshold}) as active_server_count,
+      (SELECT COUNT(*) FROM servers WHERE removed_at IS NULL) as server_count,
+      (SELECT COUNT(*) FROM servers WHERE last_seen > ${activeThreshold} AND removed_at IS NULL) as active_server_count,
       (SELECT COUNT(*) FROM containers) as container_count,
       (SELECT COUNT(*) FROM containers WHERE health_status = 'healthy') as healthy_container_count,
       (SELECT COUNT(*) FROM containers WHERE health_status != 'healthy') as unhealthy_container_count,

--- a/packages/cli/src/lib/network/daemon.ts
+++ b/packages/cli/src/lib/network/daemon.ts
@@ -166,6 +166,8 @@ Environment="JIJI_INTERFACE=${interfaceName}"
 Environment="JIJI_CORROSION_API=http://127.0.0.1:${CORROSION_API_PORT}"
 Environment="JIJI_CORROSION_DIR=/opt/jiji/corrosion"
 Environment="JIJI_LOOP_INTERVAL=30"
+Environment="JIJI_PEER_CACHE=/var/lib/jiji/peers.json"
+StateDirectory=jiji
 Restart=always
 RestartSec=10
 StandardOutput=journal

--- a/packages/cli/src/lib/network/setup.ts
+++ b/packages/cli/src/lib/network/setup.ts
@@ -198,6 +198,134 @@ async function waitForNetworkReady(
 }
 
 /**
+ * Result of attempting to recover a missing container-network bridge.
+ */
+export interface BridgeRecoveryResult {
+  recovered: boolean;
+  /** Populated when reload + recreate both failed, with the underlying cause. */
+  failureReason?: string;
+  /** Populated when recreate was refused because containers are attached. */
+  attachedContainers?: string[];
+}
+
+/**
+ * Recover a container-network bridge interface that exists in the engine's
+ * network definition but is missing from the kernel.
+ *
+ * This shows up after reboots or container engine updates: `podman network
+ * inspect jiji` reports the network just fine, but `ip link show podman1`
+ * returns nothing and any container using the network has no external
+ * connectivity. `podman network reload --all` is the documented fix but
+ * silently no-ops in some states (we hit this on a node where it couldn't
+ * recreate the bridge — exit 0, no bridge, no actionable error).
+ *
+ * Strategy, in order:
+ *   1. Try `<engine> network reload --all`. Capture stderr so a real
+ *      failure surfaces to the caller instead of being eaten by `|| true`.
+ *   2. If the bridge appeared, we're done.
+ *   3. Otherwise check whether any containers are attached to the network.
+ *      If yes, refuse — `network rm` would fail (and even if it didn't,
+ *      we'd disconnect them from the network without warning).
+ *   4. With no containers attached, rm the network and re-create it with
+ *      the same subnet/gateway, then wait for it to come up and verify
+ *      the bridge exists.
+ */
+export async function recoverMissingBridge(
+  ssh: SSHManager,
+  engine: "docker" | "podman",
+  networkName: string,
+  bridgeName: string,
+  containerSubnet: string,
+  containerGateway: string,
+): Promise<BridgeRecoveryResult> {
+  // Step 1: try reload and actually inspect the result.
+  const reload = await ssh.executeCommand(
+    `${engine} network reload --all`,
+  );
+  if (reload.code !== 0) {
+    log.debug(
+      `${engine} network reload --all failed: ${reload.stderr.trim()}`,
+      "network",
+    );
+  }
+
+  // Step 2: did reload bring the bridge back?
+  const bridgeAfterReload = await ssh.executeCommand(
+    `ip link show ${bridgeName} 2>/dev/null`,
+  );
+  if (bridgeAfterReload.code === 0) {
+    return { recovered: true };
+  }
+
+  // Step 3: check for attached containers before doing anything destructive.
+  const containersResult = await ssh.executeCommand(
+    `${engine} ps -a --filter network=${networkName} --format '{{.Names}}'`,
+  );
+  const attachedContainers = containersResult.stdout.trim().split("\n")
+    .filter((c) => c.length > 0);
+
+  if (attachedContainers.length > 0) {
+    return {
+      recovered: false,
+      attachedContainers,
+      failureReason:
+        `Reload did not restore bridge ${bridgeName}, and ${attachedContainers.length} container(s) are still attached to the network. Stop or move them, then re-run setup.`,
+    };
+  }
+
+  // Step 4: rm + create with the same subnet/gateway.
+  const rm = await ssh.executeCommand(
+    `${engine} network rm ${networkName}`,
+  );
+  if (rm.code !== 0) {
+    return {
+      recovered: false,
+      failureReason:
+        `Reload did not restore bridge ${bridgeName} and removing the network for recreate failed: ${rm.stderr.trim()}`,
+    };
+  }
+
+  const createCmd = buildNetworkCreateCmd(
+    engine,
+    networkName,
+    containerSubnet,
+    containerGateway,
+  );
+  const create = await ssh.executeCommand(createCmd);
+  if (create.code !== 0) {
+    return {
+      recovered: false,
+      failureReason:
+        `Reload did not restore bridge ${bridgeName}; subsequent network recreate failed: ${create.stderr.trim()}`,
+    };
+  }
+
+  try {
+    await waitForNetworkReady(ssh, networkName, engine, containerSubnet);
+  } catch (err) {
+    return {
+      recovered: false,
+      failureReason: `Network recreated but did not become ready: ${
+        String(err)
+      }`,
+    };
+  }
+
+  const bridgeAfterCreate = await ssh.executeCommand(
+    `ip link show ${bridgeName} 2>/dev/null`,
+  );
+  if (bridgeAfterCreate.code === 0) {
+    return { recovered: true };
+  }
+
+  return {
+    recovered: false,
+    failureReason:
+      `Network recreated but bridge ${bridgeName} is still missing. The kernel may be unable to create the bridge (check journalctl for podman/netavark errors).`,
+  };
+}
+
+/**
  * Setup private networking on servers
  *
  * This is the main entry point for network setup, called from the init command.
@@ -719,24 +847,30 @@ export async function setupNetwork(
                 );
                 if (bridgeExists.code !== 0) {
                   log.say(
-                    `├── Bridge ${bridgeName} missing, reloading container networks`,
+                    `├── Bridge ${bridgeName} missing, attempting recovery`,
                     2,
                   );
-                  await ssh.executeCommand(
-                    `${engine} network reload --all 2>/dev/null || true`,
+                  const recovery = await recoverMissingBridge(
+                    ssh,
+                    engine,
+                    networkName,
+                    bridgeName,
+                    containerSubnet,
+                    containerGateway,
                   );
-                  // Verify bridge was recreated
-                  const bridgeRecovered = await ssh.executeCommand(
-                    `ip link show ${bridgeName} 2>/dev/null`,
-                  );
-                  if (bridgeRecovered.code === 0) {
-                    log.say(
-                      `├── Bridge ${bridgeName} recovered`,
-                      2,
+                  if (recovery.recovered) {
+                    log.say(`├── Bridge ${bridgeName} recovered`, 2);
+                  } else if (recovery.attachedContainers?.length) {
+                    log.warn(
+                      `Bridge ${bridgeName} could not be recovered on ${host}: ${recovery.attachedContainers.length} container(s) attached (${
+                        recovery.attachedContainers.join(", ")
+                      }). Stop them and re-run \`jiji network setup\`.`,
                     );
                   } else {
                     log.warn(
-                      `Bridge ${bridgeName} could not be recovered on ${host}`,
+                      `Bridge ${bridgeName} could not be recovered on ${host}: ${
+                        recovery.failureReason ?? "unknown error"
+                      }`,
                     );
                   }
                 }

--- a/packages/cli/tests/bridge_recovery_test.ts
+++ b/packages/cli/tests/bridge_recovery_test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the missing-bridge recovery path in `jiji network setup`.
+ *
+ * Scenario the helper exists for: `<engine> network inspect jiji` reports
+ * the network exists, but `ip link show <bridge>` shows nothing — usually
+ * after a reboot or container engine update. `network reload --all` is the
+ * documented fix, but we hit a node in the field where reload returned
+ * success without actually recreating the bridge (silent no-op). These
+ * tests pin the three branches of the strengthened recovery flow.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { MockSSHManager } from "./mocks.ts";
+import { recoverMissingBridge } from "../src/lib/network/setup.ts";
+
+// deno-lint-ignore no-explicit-any
+const asSsh = (mock: MockSSHManager): any => mock;
+
+const ok = { success: true, stdout: "", stderr: "", code: 0 };
+const fail = (stderr = "") => ({
+  success: false,
+  stdout: "",
+  stderr,
+  code: 1,
+});
+
+Deno.test("recoverMissingBridge - reload restores the bridge (fast path)", async () => {
+  const mock = new MockSSHManager("test-host");
+
+  // Reload succeeds.
+  mock.addMockResponse("network reload --all", ok);
+  // The single ip-link check that follows the reload reports success.
+  mock.addMockResponse("ip link show podman1", ok);
+
+  const result = await recoverMissingBridge(
+    asSsh(mock),
+    "podman",
+    "jiji",
+    "podman1",
+    "10.210.129.0/24",
+    "10.210.129.1",
+  );
+
+  assertEquals(result.recovered, true);
+
+  // No destructive commands should have been issued — reload was enough.
+  const commands = mock.getAllCommands();
+  assert(
+    !commands.some((c) => c.includes("network rm")),
+    "must not run `network rm` when reload already fixed it",
+  );
+  assert(
+    !commands.some((c) => c.includes("network create")),
+    "must not run `network create` when reload already fixed it",
+  );
+});
+
+Deno.test("recoverMissingBridge - refuses recreate when containers attached", async () => {
+  const mock = new MockSSHManager("test-host");
+
+  mock.addMockResponse("network reload --all", ok);
+  // Bridge still missing after reload.
+  mock.addMockResponse("ip link show podman1", fail());
+  // Two containers are still using the network.
+  mock.addMockResponse("ps -a --filter network=jiji", {
+    success: true,
+    stdout: "casa-redis\ncasa-postgres\n",
+    stderr: "",
+    code: 0,
+  });
+
+  const result = await recoverMissingBridge(
+    asSsh(mock),
+    "podman",
+    "jiji",
+    "podman1",
+    "10.210.129.0/24",
+    "10.210.129.1",
+  );
+
+  assertEquals(result.recovered, false);
+  assertEquals(result.attachedContainers, ["casa-redis", "casa-postgres"]);
+  assert(
+    result.failureReason && result.failureReason.includes("attached"),
+    `expected reason to mention attached containers, got: ${result.failureReason}`,
+  );
+
+  const commands = mock.getAllCommands();
+  assert(
+    !commands.some((c) => c.includes("network rm")),
+    "must not run destructive `network rm` while containers are attached",
+  );
+});
+
+Deno.test("recoverMissingBridge - rm + create when no containers attached", async () => {
+  const mock = new MockSSHManager("test-host");
+
+  mock.addMockResponse("network reload --all", ok);
+  // Bridge missing after reload, then back after recreate.
+  mock.addMockResponseSequence("ip link show podman1", [
+    fail(), // first check, after reload
+    ok, // final check, after recreate
+  ]);
+  // No containers attached.
+  mock.addMockResponse("ps -a --filter network=jiji", {
+    success: true,
+    stdout: "",
+    stderr: "",
+    code: 0,
+  });
+  mock.addMockResponse("network rm jiji", ok);
+  mock.addMockResponse("network create jiji", ok);
+  // waitForNetworkReady polls `network inspect jiji` and checks subnet/gateway.
+  mock.addMockResponse(
+    "network inspect jiji",
+    {
+      success: true,
+      stdout: JSON.stringify([{
+        subnets: [
+          { subnet: "10.210.129.0/24", gateway: "10.210.129.1" },
+        ],
+      }]),
+      stderr: "",
+      code: 0,
+    },
+  );
+
+  const result = await recoverMissingBridge(
+    asSsh(mock),
+    "podman",
+    "jiji",
+    "podman1",
+    "10.210.129.0/24",
+    "10.210.129.1",
+  );
+
+  assertEquals(result.recovered, true);
+
+  const commands = mock.getAllCommands();
+  // Order matters: reload first, then rm, then create. Otherwise the helper
+  // could surprise us by reordering steps and accidentally destroying state.
+  const reloadIdx = commands.findIndex((c) => c.includes("network reload"));
+  const rmIdx = commands.findIndex((c) => c.includes("network rm jiji"));
+  const createIdx = commands.findIndex((c) =>
+    c.includes("network create jiji")
+  );
+  assert(reloadIdx >= 0 && rmIdx > reloadIdx && createIdx > rmIdx);
+});
+
+Deno.test("recoverMissingBridge - reports recreate failure with stderr", async () => {
+  const mock = new MockSSHManager("test-host");
+
+  mock.addMockResponse("network reload --all", ok);
+  mock.addMockResponse("ip link show podman1", fail());
+  mock.addMockResponse("ps -a --filter network=jiji", {
+    success: true,
+    stdout: "",
+    stderr: "",
+    code: 0,
+  });
+  mock.addMockResponse("network rm jiji", ok);
+  // Create fails with a stderr we should see in the failure reason.
+  mock.addMockResponse("network create jiji", fail("bridge name in use"));
+
+  const result = await recoverMissingBridge(
+    asSsh(mock),
+    "podman",
+    "jiji",
+    "podman1",
+    "10.210.129.0/24",
+    "10.210.129.1",
+  );
+
+  assertEquals(result.recovered, false);
+  assert(
+    result.failureReason && result.failureReason.includes("bridge name in use"),
+    `expected reason to surface stderr, got: ${result.failureReason}`,
+  );
+});
+
+Deno.test("recoverMissingBridge wiring replaces the silent reload-only path", async () => {
+  // Belt-and-braces: ensure setup.ts uses the helper and doesn't accidentally
+  // regress to the old `reload --all 2>/dev/null || true` swallow.
+  const content = await Deno.readTextFile(
+    "src/lib/network/setup.ts",
+  );
+  assert(
+    content.includes("recoverMissingBridge("),
+    "setup.ts must call recoverMissingBridge instead of inline reload",
+  );
+  assert(
+    !content.includes("network reload --all 2>/dev/null || true"),
+    "the silent `|| true` reload path must not return",
+  );
+});

--- a/packages/cli/tests/mocks.ts
+++ b/packages/cli/tests/mocks.ts
@@ -1,14 +1,21 @@
 /**
  * Mock SSH manager for testing commands that execute over SSH
  */
+type MockResponse = {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  code: number | null;
+};
+
 export class MockSSHManager {
   private commands: string[] = [];
   private shouldSucceed = true;
   private host: string;
-  private mockResponses: Map<
-    string,
-    { success: boolean; stdout: string; stderr: string; code: number | null }
-  > = new Map();
+  private mockResponses: Map<string, MockResponse> = new Map();
+  // Sequenced responses: each matching command consumes one entry; the last
+  // entry is retained as a fallback once the sequence is exhausted.
+  private mockSequences: Map<string, MockResponse[]> = new Map();
 
   constructor(host = "test-host", shouldSucceed = true) {
     this.host = host;
@@ -17,14 +24,26 @@ export class MockSSHManager {
 
   addMockResponse(
     commandPattern: string,
-    response: {
-      success: boolean;
-      stdout: string;
-      stderr: string;
-      code: number | null;
-    },
+    response: MockResponse,
   ) {
     this.mockResponses.set(commandPattern, response);
+  }
+
+  /**
+   * Register an ordered sequence of responses for commands matching this
+   * pattern. The Nth match returns the Nth entry; once exhausted, the last
+   * entry is returned for every subsequent match. Use this when a command
+   * needs to behave differently across calls (e.g. an interface check that
+   * fails before a recovery action and succeeds after).
+   */
+  addMockResponseSequence(
+    commandPattern: string,
+    responses: MockResponse[],
+  ) {
+    if (responses.length === 0) {
+      throw new Error("addMockResponseSequence requires at least one response");
+    }
+    this.mockSequences.set(commandPattern, [...responses]);
   }
 
   // Additional methods to match SSHManager interface
@@ -50,6 +69,16 @@ export class MockSSHManager {
     { success: boolean; stdout: string; stderr: string; code: number | null }
   > {
     this.commands.push(command);
+
+    // Sequenced responses take precedence over single-shot responses so
+    // tests that want to switch behaviour mid-run aren't shadowed by a
+    // broader pattern set up earlier.
+    for (const [pattern, queue] of this.mockSequences) {
+      if (command.includes(pattern)) {
+        const response = queue.length > 1 ? queue.shift()! : queue[0];
+        return Promise.resolve(response);
+      }
+    }
 
     // Check for custom mock responses first
     for (const [pattern, response] of this.mockResponses) {

--- a/packages/cli/tests/network_resilience_test.ts
+++ b/packages/cli/tests/network_resilience_test.ts
@@ -18,7 +18,8 @@ const asSsh = (mock: MockSSHManager): any => mock;
 Deno.test("applyMigrations skips when columns already exist", async () => {
   const mockSsh = new MockSSHManager("test-server");
 
-  // Mock response: column exists (count = 1)
+  // Mock response: column exists (count = 1). Matched as a substring, so both
+  // the health_status and removed_at pragma checks get the same answer.
   mockSsh.addMockResponse("pragma_table_info", {
     success: true,
     stdout: "1",
@@ -30,10 +31,11 @@ Deno.test("applyMigrations skips when columns already exist", async () => {
 
   assertEquals(result, true);
 
-  // Verify only one command was executed (the check)
+  // Two pragma_table_info checks run (health_status, then removed_at) and
+  // both short-circuit because the columns already exist.
   const commands = mockSsh.getAllCommands();
-  assertEquals(commands.length, 1);
-  assertEquals(commands[0].includes("pragma_table_info"), true);
+  assertEquals(commands.length, 2);
+  assertEquals(commands.every((c) => c.includes("pragma_table_info")), true);
 });
 
 Deno.test("applyMigrations applies migration when columns missing", async () => {

--- a/packages/cli/tests/tombstone_test.ts
+++ b/packages/cli/tests/tombstone_test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for tombstone-based server removal.
+ *
+ * Covers tombstoneServer() behavior over a mock SSH session, and schema-level
+ * regression checks that ensure every server-table reader still filters by
+ * removed_at (so a partial Corrosion view can't re-introduce the split-brain
+ * peer-eviction bug we fixed).
+ */
+
+import { assertEquals } from "@std/assert";
+import { MockSSHManager } from "./mocks.ts";
+import { tombstoneServer } from "../src/lib/network/corrosion.ts";
+
+// deno-lint-ignore no-explicit-any
+const asSsh = (mock: MockSSHManager): any => mock;
+
+Deno.test("tombstoneServer - returns not-found when row doesn't exist", async () => {
+  const mockSsh = new MockSSHManager("test-host");
+
+  // SELECT id, IFNULL(removed_at, 0) returns empty stdout for no row.
+  mockSsh.addMockResponse("SELECT id, IFNULL(removed_at, 0)", {
+    success: true,
+    stdout: "",
+    stderr: "",
+    code: 0,
+  });
+
+  const result = await tombstoneServer(asSsh(mockSsh), "ghost-server");
+
+  assertEquals(result, { tombstoned: false, alreadyRemoved: false });
+
+  // We must not have issued an UPDATE for a row that doesn't exist.
+  const updates = mockSsh.getAllCommands().filter((c) =>
+    c.includes("UPDATE servers SET removed_at")
+  );
+  assertEquals(updates.length, 0);
+});
+
+Deno.test("tombstoneServer - no-op when row already tombstoned", async () => {
+  const mockSsh = new MockSSHManager("test-host");
+
+  // Row exists, removed_at = 1700000000000 (already tombstoned).
+  mockSsh.addMockResponse("SELECT id, IFNULL(removed_at, 0)", {
+    success: true,
+    stdout: "caja03|1700000000000",
+    stderr: "",
+    code: 0,
+  });
+
+  const result = await tombstoneServer(asSsh(mockSsh), "caja03");
+
+  assertEquals(result, { tombstoned: true, alreadyRemoved: true });
+
+  // No UPDATE should fire — the row is already tombstoned and we must not
+  // overwrite the original timestamp.
+  const updates = mockSsh.getAllCommands().filter((c) =>
+    c.includes("UPDATE servers SET removed_at")
+  );
+  assertEquals(updates.length, 0);
+});
+
+Deno.test("tombstoneServer - writes tombstone for active row", async () => {
+  const mockSsh = new MockSSHManager("test-host");
+
+  // Row exists, removed_at IS NULL → IFNULL returns 0.
+  mockSsh.addMockResponse("SELECT id, IFNULL(removed_at, 0)", {
+    success: true,
+    stdout: "caja03|0",
+    stderr: "",
+    code: 0,
+  });
+
+  // The UPDATE goes via the curl-to-corrosion-API path; succeed silently.
+  mockSsh.addMockResponse("UPDATE servers SET removed_at", {
+    success: true,
+    stdout: "",
+    stderr: "",
+    code: 0,
+  });
+
+  const result = await tombstoneServer(asSsh(mockSsh), "caja03");
+
+  assertEquals(result, { tombstoned: true, alreadyRemoved: false });
+
+  const updates = mockSsh.getAllCommands().filter((c) =>
+    c.includes("UPDATE servers SET removed_at")
+  );
+  assertEquals(updates.length, 1);
+  // The UPDATE must include the WHERE id = ... AND removed_at IS NULL guard
+  // so a concurrent tombstone doesn't get clobbered.
+  assertEquals(
+    updates[0].includes("removed_at IS NULL"),
+    true,
+    `expected concurrent-write guard in UPDATE, got: ${updates[0]}`,
+  );
+});
+
+// --- Schema-level regression tests ---------------------------------------
+// These read source files and assert on substrings, matching the existing
+// pattern in network_resilience_test.ts. The point is to catch regressions
+// where someone adds a new server-table reader without filtering by
+// removed_at, which would re-open the door to the split-brain peer eviction.
+
+Deno.test("CORROSION_SCHEMA includes removed_at tombstone column", async () => {
+  const content = await Deno.readTextFile("src/lib/network/corrosion.ts");
+  assertEquals(
+    content.includes("removed_at INTEGER DEFAULT NULL"),
+    true,
+    "Missing removed_at column in servers schema",
+  );
+});
+
+Deno.test("registerServer preserves removed_at on conflict", async () => {
+  const content = await Deno.readTextFile("src/lib/network/corrosion.ts");
+  // The UPSERT in registerServer must NOT touch removed_at. If a future
+  // change reverts to INSERT OR REPLACE (or adds removed_at to the SET list),
+  // re-running `jiji network setup` would silently un-tombstone servers.
+  assertEquals(
+    content.includes("ON CONFLICT(id) DO UPDATE SET"),
+    true,
+    "registerServer must use UPSERT, not INSERT OR REPLACE",
+  );
+  const upsertStart = content.indexOf("ON CONFLICT(id) DO UPDATE SET");
+  const upsertSection = content.slice(upsertStart, upsertStart + 500);
+  assertEquals(
+    upsertSection.includes("removed_at"),
+    false,
+    "registerServer UPSERT must not write removed_at — it would clobber tombstones",
+  );
+});
+
+Deno.test("queryActiveServers excludes tombstoned rows", async () => {
+  const content = await Deno.readTextFile("src/lib/network/corrosion.ts");
+  const fnStart = content.indexOf("export async function queryActiveServers");
+  const fnSection = content.slice(fnStart, fnStart + 800);
+  assertEquals(
+    fnSection.includes("removed_at IS NULL"),
+    true,
+    "queryActiveServers must filter removed_at IS NULL",
+  );
+});
+
+Deno.test("queryAllServers excludes tombstoned rows by default", async () => {
+  const content = await Deno.readTextFile("src/lib/network/corrosion.ts");
+  const fnStart = content.indexOf("export async function queryAllServers");
+  const fnSection = content.slice(fnStart, fnStart + 1000);
+  assertEquals(
+    fnSection.includes("includeRemoved"),
+    true,
+    "queryAllServers must support an includeRemoved flag",
+  );
+  assertEquals(
+    fnSection.includes("removed_at IS NULL"),
+    true,
+    "queryAllServers must filter removed_at IS NULL by default",
+  );
+});
+
+Deno.test("queryOfflineServers excludes tombstoned rows", async () => {
+  const content = await Deno.readTextFile("src/lib/network/corrosion.ts");
+  const fnStart = content.indexOf("export async function queryOfflineServers");
+  const fnSection = content.slice(fnStart, fnStart + 800);
+  assertEquals(
+    fnSection.includes("removed_at IS NULL"),
+    true,
+    "queryOfflineServers must filter removed_at IS NULL",
+  );
+});

--- a/packages/daemon/src/garbage_collector.ts
+++ b/packages/daemon/src/garbage_collector.ts
@@ -37,6 +37,10 @@ export async function garbageCollect(
   // Delete containers that have been unhealthy for more than 3 minutes
   deleted += await deleteStaleContainers(client, cli);
 
+  // Delete containers belonging to explicitly-tombstoned servers immediately.
+  // This is positive evidence the server is gone — no grace period needed.
+  deleted += await deleteTombstonedServerContainers(client, cli);
+
   // Delete containers from offline servers (no heartbeat in 10 minutes)
   deleted += await deleteOfflineServerContainers(config, client, cli);
 
@@ -84,6 +88,40 @@ async function deleteStaleContainers(
   return deleted;
 }
 
+async function deleteTombstonedServerContainers(
+  client: CorrosionClient,
+  cli: CorrosionCli,
+): Promise<number> {
+  const rows = await cli.query(
+    sql`SELECT id FROM servers WHERE removed_at IS NOT NULL;`,
+  );
+
+  let deleted = 0;
+  for (const [serverId] of rows) {
+    if (!serverId) continue;
+
+    if (!isValidServerId(serverId)) {
+      log.warn("Skipping tombstoned server with invalid ID format", {
+        server_id: serverId,
+      });
+      continue;
+    }
+
+    const affected = await client.execGetRowsAffected(
+      sql`DELETE FROM containers WHERE server_id = ${serverId};`,
+    );
+    if (affected > 0) {
+      log.info("Removed containers for tombstoned server", {
+        server_id: serverId,
+        removed: affected,
+      });
+    }
+    deleted += affected;
+  }
+
+  return deleted;
+}
+
 async function deleteOfflineServerContainers(
   config: Config,
   client: CorrosionClient,
@@ -93,7 +131,7 @@ async function deleteOfflineServerContainers(
   const threshold = now - OFFLINE_SERVER_THRESHOLD;
 
   const rows = await cli.query(
-    sql`SELECT id FROM servers WHERE last_seen < ${threshold} AND id != ${config.serverId};`,
+    sql`SELECT id FROM servers WHERE last_seen < ${threshold} AND removed_at IS NULL AND id != ${config.serverId};`,
   );
 
   let deleted = 0;

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -16,9 +16,9 @@ import { syncContainerHealth } from "./container_sync.ts";
 import { garbageCollect } from "./garbage_collector.ts";
 import { updatePublicIp } from "./ip_discovery.ts";
 import { checkCorrosionHealth } from "./corrosion_health.ts";
-import { detectSplitBrain } from "./split_brain.ts";
+import { detectSplitBrain, isSplitBrainDetected } from "./split_brain.ts";
 import { reconcileNetworkBridge } from "./network_bridge.ts";
-import { hydrateFromCache } from "./peer_cache.ts";
+import { healSplitBrain, hydrateFromCache } from "./peer_cache.ts";
 import { sql } from "./validation.ts";
 
 /** Run garbage collection every 10 iterations (~5 min at default 30s interval) */
@@ -158,6 +158,15 @@ async function main(): Promise<void> {
       // 8. Detect cluster partition (every 20 iterations = 10 minutes)
       if (iteration % SPLIT_BRAIN_INTERVAL === 0) {
         await detectSplitBrain(config, cli);
+      }
+
+      // 8a. Heal split-brain (every iteration while flag is set).
+      // Detection runs every 10 minutes but the flag is sticky until the
+      // next detection clears it; heal runs every loop tick so peers get
+      // ~30s between re-handshake attempts — the right cadence for
+      // WireGuard to actually settle a new endpoint.
+      if (isSplitBrainDetected()) {
+        await healSplitBrain(config.interfaceName, config.peerCachePath);
       }
 
       // 9. Check container network bridge (every 10 iterations = 5 minutes)

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -18,6 +18,7 @@ import { updatePublicIp } from "./ip_discovery.ts";
 import { checkCorrosionHealth } from "./corrosion_health.ts";
 import { detectSplitBrain } from "./split_brain.ts";
 import { reconcileNetworkBridge } from "./network_bridge.ts";
+import { hydrateFromCache } from "./peer_cache.ts";
 import { sql } from "./validation.ts";
 
 /** Run garbage collection every 10 iterations (~5 min at default 30s interval) */
@@ -94,6 +95,27 @@ async function main(): Promise<void> {
 
   Deno.addSignalListener("SIGTERM", shutdown);
   Deno.addSignalListener("SIGINT", shutdown);
+
+  // Seed WireGuard from the last-known-good peer set before the first
+  // reconcile. Without this, a daemon that boots while Corrosion is
+  // unreachable can't bring up any peers (which is the gossip path itself).
+  try {
+    const seeded = await hydrateFromCache(
+      config.interfaceName,
+      config.peerCachePath,
+    );
+    if (seeded > 0) {
+      log.info("Seeded WireGuard from peer cache", {
+        path: config.peerCachePath,
+        peers: seeded,
+      });
+    }
+  } catch (err) {
+    log.warn("Peer cache hydrate failed, continuing without seed", {
+      path: config.peerCachePath,
+      error: String(err),
+    });
+  }
 
   // Main loop
   while (!shuttingDown) {

--- a/packages/daemon/src/network_bridge.ts
+++ b/packages/daemon/src/network_bridge.ts
@@ -2,93 +2,219 @@
  * Container network bridge health check and recovery.
  *
  * Detects when the podman/docker bridge interface is missing
- * (e.g., after a reboot or engine update) and recovers by
- * reloading all container networks.
+ * (e.g., after a reboot or engine update) and recovers it.
+ *
+ * Strategy:
+ *   1. `<engine> network reload --all` — the documented fix.
+ *   2. If reload returns success but the bridge is still missing (we hit
+ *      this in the field on some nodes), fall back to remove + recreate
+ *      with the same subnet/gateway, but only when no containers are
+ *      attached. With attached containers, refuse and log them — `rm`
+ *      would either fail or silently disconnect workloads.
  */
 
 import type { Config } from "./types.ts";
 import * as log from "./logger.ts";
 
-/**
- * Check if the container network bridge exists and recover if missing.
- *
- * The jiji container network uses a bridge interface (e.g., podman1)
- * for container-to-host and cross-server traffic. If this bridge
- * disappears (reboot, engine update), containers lose all external
- * connectivity while appearing to still run.
- */
+interface NetworkInfo {
+  bridgeName?: string;
+  subnet?: string;
+  gateway?: string;
+}
+
+const NETWORK_NAME = "jiji";
+
 export async function reconcileNetworkBridge(
   config: Config,
 ): Promise<void> {
   const engine = config.engine;
 
-  // Check if the jiji network exists
-  const inspectCmd = new Deno.Command(engine, {
-    args: ["network", "inspect", "jiji"],
-    stdout: "piped",
-    stderr: "piped",
-  });
-
-  const inspectOutput = await inspectCmd.output();
-  if (!inspectOutput.success) {
-    // No jiji network configured — nothing to reconcile
+  const info = await inspectNetwork(engine);
+  if (!info.bridgeName) {
+    // No jiji network configured — nothing to reconcile.
     return;
   }
 
-  // Parse the network to find the expected bridge interface
-  const stdout = new TextDecoder().decode(inspectOutput.stdout);
-  let bridgeName: string | undefined;
-  try {
-    const networkData = JSON.parse(stdout);
-    const network = networkData[0] ?? networkData;
-    // Podman format
-    bridgeName = network.network_interface ??
-      // Docker format
-      network.Options?.["com.docker.network.bridge.name"];
-  } catch {
-    log.warn("Failed to parse jiji network inspect output");
+  if (await bridgeExists(info.bridgeName)) {
     return;
   }
 
-  if (!bridgeName) {
-    return;
-  }
-
-  // Check if the bridge interface actually exists
-  const linkCmd = new Deno.Command("ip", {
-    args: ["link", "show", bridgeName],
-    stdout: "piped",
-    stderr: "piped",
-  });
-
-  const linkOutput = await linkCmd.output();
-  if (linkOutput.success) {
-    // Bridge exists, nothing to do
-    return;
-  }
-
-  // Bridge is missing — recover by reloading all container networks
   log.warn("Container network bridge missing, recovering", {
-    bridge: bridgeName,
+    bridge: info.bridgeName,
   });
 
-  const reloadCmd = new Deno.Command(engine, {
-    args: ["network", "reload", "--all"],
-    stdout: "piped",
-    stderr: "piped",
-  });
+  // Step 1: try reload.
+  const reload = await runCmd(engine, ["network", "reload", "--all"]);
+  if (!reload.success) {
+    log.warn("network reload --all failed (continuing to fallback)", {
+      stderr: reload.stderr.trim(),
+    });
+  }
 
-  const reloadOutput = await reloadCmd.output();
+  if (await bridgeExists(info.bridgeName)) {
+    log.info("Container network bridge recovered via reload", {
+      bridge: info.bridgeName,
+    });
+    return;
+  }
 
-  if (reloadOutput.success) {
-    log.info("Container network bridge recovered", {
-      bridge: bridgeName,
+  // Step 2: check for attached containers before destructive recreate.
+  if (!info.subnet) {
+    log.error(
+      "Cannot recreate network: subnet not found in inspect output. Investigate manually.",
+      { bridge: info.bridgeName },
+    );
+    return;
+  }
+
+  // Docker networks rely on engine-specific options (bridge name,
+  // trusted_host_interfaces) that we can't always round-trip from inspect.
+  // Re-run `jiji network setup` from the CLI for docker clusters — it has
+  // the full option set in scope.
+  if (engine === "docker") {
+    log.error(
+      "Bridge still missing after reload on docker. Re-run `jiji network setup` to recreate the network with the correct engine options.",
+      { bridge: info.bridgeName },
+    );
+    return;
+  }
+
+  const attached = await listAttachedContainers(engine);
+  if (attached.length > 0) {
+    log.error(
+      "Bridge still missing after reload, and containers are attached. Refusing to recreate the network (would disconnect workloads).",
+      {
+        bridge: info.bridgeName,
+        attached_containers: attached,
+      },
+    );
+    return;
+  }
+
+  // Step 3: rm + create with the existing subnet/gateway.
+  const rm = await runCmd(engine, ["network", "rm", NETWORK_NAME]);
+  if (!rm.success) {
+    log.error("Failed to remove network for recreate", {
+      bridge: info.bridgeName,
+      stderr: rm.stderr.trim(),
+    });
+    return;
+  }
+
+  const createArgs = buildCreateArgs(engine, info.subnet, info.gateway);
+  const create = await runCmd(engine, createArgs);
+  if (!create.success) {
+    log.error("Failed to recreate network", {
+      bridge: info.bridgeName,
+      stderr: create.stderr.trim(),
+    });
+    return;
+  }
+
+  if (await bridgeExists(info.bridgeName)) {
+    log.info("Container network bridge recovered via recreate", {
+      bridge: info.bridgeName,
+      subnet: info.subnet,
     });
   } else {
-    const stderr = new TextDecoder().decode(reloadOutput.stderr);
-    log.error("Failed to recover container network bridge", {
-      bridge: bridgeName,
-      error: stderr,
-    });
+    log.error(
+      "Network recreated but bridge is still missing. The kernel may be unable to create the bridge (check journalctl for podman/netavark errors).",
+      { bridge: info.bridgeName },
+    );
   }
+}
+
+async function inspectNetwork(
+  engine: "docker" | "podman",
+): Promise<NetworkInfo> {
+  const result = await runCmd(engine, ["network", "inspect", NETWORK_NAME]);
+  if (!result.success) {
+    return {};
+  }
+
+  try {
+    const data = JSON.parse(result.stdout);
+    const network = data[0] ?? data;
+
+    const bridgeName: string | undefined = network.network_interface ??
+      network.Options?.["com.docker.network.bridge.name"];
+
+    let subnet: string | undefined;
+    let gateway: string | undefined;
+    // Podman (modern) format
+    if (network.subnets && network.subnets[0]) {
+      subnet = network.subnets[0].subnet;
+      gateway = network.subnets[0].gateway;
+    } else if (
+      network.IPAM && network.IPAM.Config && network.IPAM.Config[0]
+    ) {
+      // Docker format
+      subnet = network.IPAM.Config[0].Subnet;
+      gateway = network.IPAM.Config[0].Gateway;
+    }
+
+    return { bridgeName, subnet, gateway };
+  } catch {
+    log.warn("Failed to parse jiji network inspect output");
+    return {};
+  }
+}
+
+async function bridgeExists(bridgeName: string): Promise<boolean> {
+  const result = await runCmd("ip", ["link", "show", bridgeName]);
+  return result.success;
+}
+
+async function listAttachedContainers(
+  engine: "docker" | "podman",
+): Promise<string[]> {
+  const result = await runCmd(engine, [
+    "ps",
+    "-a",
+    "--filter",
+    `network=${NETWORK_NAME}`,
+    "--format",
+    "{{.Names}}",
+  ]);
+  if (!result.success) return [];
+  return result.stdout.trim().split("\n").filter((n) => n.length > 0);
+}
+
+function buildCreateArgs(
+  _engine: "docker" | "podman",
+  subnet: string,
+  gateway?: string,
+): string[] {
+  // Only podman gets here — docker is rejected before calling this helper
+  // because we can't round-trip the docker bridge options from inspect.
+  // Match the CLI's setup flag so daemon recreate doesn't drift from
+  // what `jiji network setup` produces.
+  const args = [
+    "network",
+    "create",
+    NETWORK_NAME,
+    `--subnet=${subnet}`,
+    "--disable-dns",
+  ];
+  if (gateway) {
+    args.push(`--gateway=${gateway}`);
+  }
+  return args;
+}
+
+async function runCmd(
+  bin: string,
+  args: string[],
+): Promise<{ success: boolean; stdout: string; stderr: string }> {
+  const cmd = new Deno.Command(bin, {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await cmd.output();
+  return {
+    success: output.success,
+    stdout: new TextDecoder().decode(output.stdout),
+    stderr: new TextDecoder().decode(output.stderr),
+  };
 }

--- a/packages/daemon/src/peer_cache.ts
+++ b/packages/daemon/src/peer_cache.ts
@@ -19,6 +19,7 @@
  */
 
 import * as wg from "./wireguard.ts";
+import { PEER_DOWN_THRESHOLD, type PeerState } from "./types.ts";
 import {
   isValidCIDR,
   isValidEndpoint,
@@ -178,6 +179,114 @@ export async function hydrateFromCache(
   }
 
   return seeded;
+}
+
+/**
+ * Heal a detected split-brain by exercising every cached peer entry.
+ *
+ * When split-brain is active, Corrosion gossip is by definition broken,
+ * so the normal reconciliation paths can't recover on their own:
+ *
+ *   - `reconcilePeers` reads peer rows from Corrosion → may have a partial
+ *     view → can't add peers it doesn't know about.
+ *   - `peer_monitor.tryRotateEndpoint` reads endpoint lists from Corrosion
+ *     to pick the next endpoint → can't rotate during a partition.
+ *
+ * This function uses the on-disk cache as an out-of-band source of truth.
+ * It only takes additive actions:
+ *
+ *   - Cached peers missing from WG: add with the first cached endpoint.
+ *   - Cached peers present but with a stale handshake: rotate to the next
+ *     cached endpoint (same behaviour as peer_monitor, but cache-sourced).
+ *
+ * Peers that never handshaked (latestHandshake === 0) are left alone, the
+ * same way peer_monitor handles them — we have no evidence that the
+ * current endpoint is wrong yet.
+ */
+export async function healSplitBrain(
+  interfaceName: string,
+  cachePath: string,
+): Promise<{ added: number; rotated: number }> {
+  const cache = await loadCache(cachePath);
+  if (!cache) {
+    log.warn("Split-brain heal skipped: no cache available", {
+      path: cachePath,
+    });
+    return { added: 0, rotated: 0 };
+  }
+
+  let current: PeerState[];
+  try {
+    current = await wg.showDump(interfaceName);
+  } catch (err) {
+    log.warn("Split-brain heal skipped: cannot read WireGuard state", {
+      interface: interfaceName,
+      error: String(err),
+    });
+    return { added: 0, rotated: 0 };
+  }
+
+  const currentByKey = new Map(current.map((p) => [p.publicKey, p]));
+  const now = Math.floor(Date.now() / 1000);
+
+  let added = 0;
+  let rotated = 0;
+
+  for (const peer of cache.peers) {
+    if (!isValidCachedPeer(peer)) continue;
+
+    const existing = currentByKey.get(peer.publicKey);
+
+    if (!existing) {
+      try {
+        await wg.setPeer(interfaceName, {
+          publicKey: peer.publicKey,
+          allowedIps: peer.allowedIps,
+          endpoint: peer.endpoints[0],
+          persistentKeepalive: peer.persistentKeepalive,
+        });
+        log.info("Split-brain heal: re-added missing peer", {
+          pubkey: peer.publicKey,
+          endpoint: peer.endpoints[0],
+        });
+        added++;
+      } catch (err) {
+        log.warn("Split-brain heal: failed to re-add peer", {
+          pubkey: peer.publicKey,
+          error: String(err),
+        });
+      }
+      continue;
+    }
+
+    // Peer is in WG. Only rotate if it has handshaked at least once and the
+    // last handshake is older than the down-threshold — otherwise we'd
+    // flap endpoints on a peer that's just slow to come up.
+    if (existing.latestHandshake === 0) continue;
+    if (now - existing.latestHandshake <= PEER_DOWN_THRESHOLD) continue;
+    if (peer.endpoints.length <= 1) continue;
+
+    const idx = peer.endpoints.indexOf(existing.endpoint);
+    const next = peer.endpoints[(idx + 1) % peer.endpoints.length];
+    if (next === existing.endpoint) continue;
+
+    try {
+      await wg.updateEndpoint(interfaceName, peer.publicKey, next);
+      log.info("Split-brain heal: rotated stale endpoint", {
+        pubkey: peer.publicKey,
+        from: existing.endpoint,
+        to: next,
+      });
+      rotated++;
+    } catch (err) {
+      log.warn("Split-brain heal: failed to rotate endpoint", {
+        pubkey: peer.publicKey,
+        error: String(err),
+      });
+    }
+  }
+
+  return { added, rotated };
 }
 
 function parentDir(path: string): string | null {

--- a/packages/daemon/src/peer_cache.ts
+++ b/packages/daemon/src/peer_cache.ts
@@ -1,0 +1,222 @@
+/**
+ * On-disk cache of the WireGuard peer set.
+ *
+ * Purpose: break the chicken-and-egg between WireGuard and Corrosion. The
+ * reconciler reads peers from Corrosion, but Corrosion gossip needs the
+ * WireGuard mesh to function. If the daemon boots into a clean WG interface
+ * (e.g. after `wg-quick down` + reboot, or a fresh install) and Corrosion
+ * is reachable only via the very peers we don't have yet, we'd be stuck.
+ *
+ * Each successful reconcile snapshots the intended peer set to disk. At
+ * daemon startup we seed WG from that snapshot before consulting Corrosion,
+ * so the mesh is operational immediately.
+ *
+ * The cache is additive on read: we only call `wg set peer`, never
+ * `wg removePeer`. Tombstone-driven removal happens in the normal
+ * reconcile cycle once Corrosion is reachable. If the cache contains a
+ * peer that's since been tombstoned cluster-wide, it'll come back briefly
+ * and be removed on the next reconcile — acceptable.
+ */
+
+import * as wg from "./wireguard.ts";
+import {
+  isValidCIDR,
+  isValidEndpoint,
+  isValidWireGuardKey,
+} from "./validation.ts";
+import * as log from "./logger.ts";
+
+const SCHEMA_VERSION = 1;
+
+export interface CachedPeer {
+  publicKey: string;
+  allowedIps: string;
+  endpoints: string[];
+  persistentKeepalive: number;
+}
+
+export interface PeerCacheFile {
+  version: number;
+  updatedAt: number;
+  peers: CachedPeer[];
+}
+
+/**
+ * Load and parse the cache file. Returns null when the file is missing,
+ * unreadable, malformed, or carries a future schema version — never throws.
+ * Callers should treat a null as "no cache available" and proceed.
+ */
+export async function loadCache(
+  path: string,
+): Promise<PeerCacheFile | null> {
+  let text: string;
+  try {
+    text = await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      return null;
+    }
+    log.warn("Failed to read peer cache, ignoring", {
+      path,
+      error: String(err),
+    });
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    log.warn("Peer cache is not valid JSON, ignoring", {
+      path,
+      error: String(err),
+    });
+    return null;
+  }
+
+  if (!isPeerCacheFile(parsed)) {
+    log.warn("Peer cache failed shape validation, ignoring", { path });
+    return null;
+  }
+
+  if (parsed.version > SCHEMA_VERSION) {
+    log.warn("Peer cache schema version is newer than supported, ignoring", {
+      path,
+      cache_version: parsed.version,
+      supported_version: SCHEMA_VERSION,
+    });
+    return null;
+  }
+
+  return parsed;
+}
+
+/**
+ * Atomically persist the peer set. Writes to `<path>.tmp` then renames over
+ * the target so a crash mid-write can never leave a corrupted file in place.
+ * Creates parent directories as needed.
+ */
+export async function saveCache(
+  path: string,
+  peers: CachedPeer[],
+): Promise<void> {
+  const parent = parentDir(path);
+  if (parent) {
+    await Deno.mkdir(parent, { recursive: true });
+  }
+
+  const file: PeerCacheFile = {
+    version: SCHEMA_VERSION,
+    updatedAt: Date.now(),
+    peers,
+  };
+
+  const tmp = `${path}.tmp`;
+  await Deno.writeTextFile(tmp, JSON.stringify(file, null, 2), {
+    mode: 0o640,
+  });
+  await Deno.rename(tmp, path);
+}
+
+/**
+ * Seed WireGuard from the cache. Only adds peers that are missing on the
+ * interface; never removes. Returns the number of peers actually set.
+ * Invalid cached entries are skipped with a warning so a partially-bad
+ * cache can't take down the whole hydrate.
+ */
+export async function hydrateFromCache(
+  interfaceName: string,
+  path: string,
+): Promise<number> {
+  const cache = await loadCache(path);
+  if (!cache) {
+    return 0;
+  }
+
+  let existing: Set<string>;
+  try {
+    const peers = await wg.showDump(interfaceName);
+    existing = new Set(peers.map((p) => p.publicKey));
+  } catch (err) {
+    // If we can't even read WG state, the interface probably isn't up.
+    // Bail out — hydrating would fail anyway.
+    log.warn("Cannot read WireGuard state, skipping cache hydrate", {
+      interface: interfaceName,
+      error: String(err),
+    });
+    return 0;
+  }
+
+  let seeded = 0;
+  for (const peer of cache.peers) {
+    if (existing.has(peer.publicKey)) {
+      continue;
+    }
+
+    if (!isValidCachedPeer(peer)) {
+      log.warn("Skipping invalid peer in cache", {
+        pubkey: peer.publicKey,
+      });
+      continue;
+    }
+
+    const endpoint = peer.endpoints[0];
+    try {
+      await wg.setPeer(interfaceName, {
+        publicKey: peer.publicKey,
+        allowedIps: peer.allowedIps,
+        endpoint,
+        persistentKeepalive: peer.persistentKeepalive,
+      });
+      seeded++;
+    } catch (err) {
+      log.warn("Failed to seed peer from cache", {
+        pubkey: peer.publicKey,
+        error: String(err),
+      });
+    }
+  }
+
+  return seeded;
+}
+
+function parentDir(path: string): string | null {
+  const idx = path.lastIndexOf("/");
+  if (idx <= 0) return null;
+  return path.slice(0, idx);
+}
+
+function isPeerCacheFile(value: unknown): value is PeerCacheFile {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.version !== "number") return false;
+  if (typeof v.updatedAt !== "number") return false;
+  if (!Array.isArray(v.peers)) return false;
+  return v.peers.every(isCachedPeer);
+}
+
+function isCachedPeer(value: unknown): value is CachedPeer {
+  if (!value || typeof value !== "object") return false;
+  const p = value as Record<string, unknown>;
+  if (typeof p.publicKey !== "string") return false;
+  if (typeof p.allowedIps !== "string") return false;
+  if (!Array.isArray(p.endpoints)) return false;
+  if (!p.endpoints.every((e) => typeof e === "string")) return false;
+  if (typeof p.persistentKeepalive !== "number") return false;
+  return true;
+}
+
+/**
+ * Stricter check used at hydrate time to keep malformed payloads out of `wg`.
+ */
+function isValidCachedPeer(peer: CachedPeer): boolean {
+  if (!isValidWireGuardKey(peer.publicKey)) return false;
+  if (peer.endpoints.length === 0) return false;
+  if (!isValidEndpoint(peer.endpoints[0])) return false;
+  // allowedIps is a comma-separated list; verify each entry is a CIDR.
+  const allowed = peer.allowedIps.split(",").map((s) => s.trim()).filter(
+    Boolean,
+  );
+  if (allowed.length === 0) return false;
+  return allowed.every(isValidCIDR);
+}

--- a/packages/daemon/src/peer_reconciler.ts
+++ b/packages/daemon/src/peer_reconciler.ts
@@ -1,7 +1,11 @@
 /**
  * Reconcile WireGuard peers with Corrosion state.
  *
- * Adds missing peers and removes stale ones.
+ * Additive by default: adds missing peers, fixes incorrect AllowedIPs, and
+ * removes peers only when their server row is explicitly tombstoned
+ * (removed_at IS NOT NULL). Absence from the Corrosion view is never treated
+ * as a removal signal — that turns transient gossip partitions into permanent
+ * mesh tears.
  */
 
 import type { Config, ServerRecord } from "./types.ts";
@@ -33,14 +37,18 @@ export function parseEndpoints(raw: string): string[] {
 }
 
 /**
- * Get active servers from Corrosion (seen in last 5 minutes).
+ * Get all non-tombstoned peer servers from Corrosion.
+ *
+ * We deliberately do NOT filter by last_seen: a server being temporarily
+ * unreachable is the exact scenario where we most need to keep its WireGuard
+ * peer in place so gossip can resume on recovery.
  */
-async function getActiveServers(
+async function getPeerServers(
   cli: CorrosionCli,
   serverId: string,
 ): Promise<ServerRecord[]> {
   const rows = await cli.query(
-    sql`SELECT wireguard_pubkey, subnet, management_ip, endpoints FROM servers WHERE last_seen > (strftime('%s', 'now') - 300) * 1000 AND id != ${serverId};`,
+    sql`SELECT wireguard_pubkey, subnet, management_ip, endpoints FROM servers WHERE removed_at IS NULL AND id != ${serverId};`,
   );
 
   return rows.filter((r) => r[0]?.trim()).map((row) => ({
@@ -54,6 +62,20 @@ async function getActiveServers(
 }
 
 /**
+ * Get pubkeys of tombstoned servers. These should be torn down from
+ * WireGuard on next reconcile cycle, cluster-wide.
+ */
+async function getTombstonedPubkeys(
+  cli: CorrosionCli,
+  serverId: string,
+): Promise<Set<string>> {
+  const rows = await cli.query(
+    sql`SELECT wireguard_pubkey FROM servers WHERE removed_at IS NOT NULL AND id != ${serverId};`,
+  );
+  return new Set(rows.map((r) => r[0]).filter((k): k is string => !!k?.trim()));
+}
+
+/**
  * Reconcile WireGuard peers with the current Corrosion state.
  */
 export async function reconcilePeers(
@@ -62,10 +84,13 @@ export async function reconcilePeers(
 ): Promise<void> {
   log.info("Reconciling WireGuard peers...");
 
-  const activeServers = await getActiveServers(cli, config.serverId);
+  const peerServers = await getPeerServers(cli, config.serverId);
+  const tombstonedPubkeys = await getTombstonedPubkeys(cli, config.serverId);
 
-  if (activeServers.length === 0) {
-    log.warn("No active servers found in Corrosion");
+  if (peerServers.length === 0 && tombstonedPubkeys.size === 0) {
+    // No peers and nothing to remove. This is normal on a fresh single-node
+    // cluster; otherwise it usually means Corrosion is empty/uninitialized.
+    log.warn("No peer servers found in Corrosion");
     return;
   }
 
@@ -74,7 +99,7 @@ export async function reconcilePeers(
   const currentPubkeys = new Set(currentPeers.map((p) => p.publicKey));
 
   // Add missing peers or fix incorrect allowed IPs
-  for (const server of activeServers) {
+  for (const server of peerServers) {
     // Validate all Corrosion-sourced peer data before passing to wg
     if (!isValidWireGuardKey(server.wireguardPubkey)) {
       log.warn("Skipping peer with invalid pubkey format", {
@@ -171,17 +196,17 @@ export async function reconcilePeers(
     }
   }
 
-  // Remove stale peers (not in active servers list)
-  const activePubkeys = new Set(
-    activeServers.map((s) => s.wireguardPubkey),
-  );
+  // Remove peers that have been explicitly tombstoned. We only remove on
+  // positive evidence (a non-null removed_at in Corrosion), never on absence
+  // from the active set — that would re-introduce the split-brain bug where a
+  // partition causes nodes to evict each other.
   for (const peer of currentPeers) {
-    if (!activePubkeys.has(peer.publicKey)) {
-      log.warn("Removing stale peer", { pubkey: peer.publicKey });
+    if (tombstonedPubkeys.has(peer.publicKey)) {
+      log.warn("Removing tombstoned peer", { pubkey: peer.publicKey });
       try {
         await wg.removePeer(config.interfaceName, peer.publicKey);
       } catch (err) {
-        log.error("Failed to remove peer", {
+        log.error("Failed to remove tombstoned peer", {
           pubkey: peer.publicKey,
           error: String(err),
         });

--- a/packages/daemon/src/peer_reconciler.ts
+++ b/packages/daemon/src/peer_reconciler.ts
@@ -18,6 +18,7 @@ import {
   isValidWireGuardKey,
   sql,
 } from "./validation.ts";
+import { type CachedPeer, saveCache } from "./peer_cache.ts";
 import * as log from "./logger.ts";
 
 /**
@@ -98,6 +99,11 @@ export async function reconcilePeers(
   const currentPeers = await wg.showDump(config.interfaceName);
   const currentPubkeys = new Set(currentPeers.map((p) => p.publicKey));
 
+  // Build the cache snapshot as we validate each server below. Only peers
+  // that pass every validation gate make it in — we don't want a stale
+  // cache to seed something `wg` would reject.
+  const cacheable: CachedPeer[] = [];
+
   // Add missing peers or fix incorrect allowed IPs
   for (const server of peerServers) {
     // Validate all Corrosion-sourced peer data before passing to wg
@@ -142,6 +148,14 @@ export async function reconcilePeers(
 
     // Compute expected allowed IPs including container subnet
     const expectedAllowedIps = computeExpectedAllowedIps(server);
+
+    // Server passed all validation gates — record it for the boot cache.
+    cacheable.push({
+      publicKey: server.wireguardPubkey,
+      allowedIps: expectedAllowedIps,
+      endpoints: server.endpoints,
+      persistentKeepalive: 25,
+    });
 
     if (!currentPubkeys.has(server.wireguardPubkey)) {
       // New peer — add it
@@ -211,6 +225,21 @@ export async function reconcilePeers(
           error: String(err),
         });
       }
+    }
+  }
+
+  // Snapshot the validated peer set so a future cold boot can seed WG
+  // without needing Corrosion to be reachable. Guard against writing an
+  // empty cache: if every peer failed validation, that's a bug, not a
+  // legitimate "no peers" state — preserve whatever the previous cache had.
+  if (cacheable.length > 0) {
+    try {
+      await saveCache(config.peerCachePath, cacheable);
+    } catch (err) {
+      log.warn("Failed to write peer cache", {
+        path: config.peerCachePath,
+        error: String(err),
+      });
     }
   }
 }

--- a/packages/daemon/src/split_brain.ts
+++ b/packages/daemon/src/split_brain.ts
@@ -27,7 +27,9 @@ export async function detectSplitBrain(
 ): Promise<void> {
   log.info("Checking for cluster partition...");
 
-  const totalStr = await cli.queryScalar("SELECT COUNT(*) FROM servers;");
+  const totalStr = await cli.queryScalar(
+    "SELECT COUNT(*) FROM servers WHERE removed_at IS NULL;",
+  );
   const totalServers = parseInt(totalStr ?? "0", 10);
 
   if (totalServers === 0) {
@@ -39,7 +41,7 @@ export async function detectSplitBrain(
   const activeThreshold = now - ACTIVE_SERVER_THRESHOLD;
 
   const activeStr = await cli.queryScalar(
-    `SELECT COUNT(*) FROM servers WHERE last_seen > ${activeThreshold};`,
+    `SELECT COUNT(*) FROM servers WHERE last_seen > ${activeThreshold} AND removed_at IS NULL;`,
   );
   const activeServers = parseInt(activeStr ?? "0", 10);
 
@@ -64,7 +66,7 @@ export async function detectSplitBrain(
 
     // Log unreachable servers for debugging
     const rows = await cli.query(
-      `SELECT hostname FROM servers WHERE last_seen <= ${activeThreshold};`,
+      `SELECT hostname FROM servers WHERE last_seen <= ${activeThreshold} AND removed_at IS NULL;`,
     );
     const unreachable = rows.map((r) => r[0]).filter(Boolean);
     if (unreachable.length > 0) {

--- a/packages/daemon/src/types.ts
+++ b/packages/daemon/src/types.ts
@@ -11,6 +11,7 @@ export interface Config {
   corrosionApi: string;
   corrosionDir: string;
   loopInterval: number;
+  peerCachePath: string;
 }
 
 /**
@@ -48,6 +49,9 @@ export function parseConfig(): Config {
     throw new Error("JIJI_LOOP_INTERVAL must be a positive integer");
   }
 
+  const peerCachePath = Deno.env.get("JIJI_PEER_CACHE") ??
+    "/var/lib/jiji/peers.json";
+
   return {
     serverId,
     engine,
@@ -55,6 +59,7 @@ export function parseConfig(): Config {
     corrosionApi,
     corrosionDir,
     loopInterval,
+    peerCachePath,
   };
 }
 

--- a/packages/daemon/tests/network_bridge_test.ts
+++ b/packages/daemon/tests/network_bridge_test.ts
@@ -1,0 +1,53 @@
+/**
+ * Source-level regression guards for the daemon's bridge recovery.
+ *
+ * `reconcileNetworkBridge` shells out to `<engine>` and `ip` directly,
+ * so a meaningful unit test would need to mock subprocess execution — out
+ * of scope here. Instead pin the invariants that make the recovery
+ * actually work: it doesn't silently swallow reload errors, it verifies
+ * the bridge after reload, it has a recreate fallback, and it refuses
+ * to wipe a network that has containers attached.
+ */
+
+import { assert, assertStringIncludes } from "@std/assert";
+
+async function source(): Promise<string> {
+  return await Deno.readTextFile("src/network_bridge.ts");
+}
+
+Deno.test("daemon bridge recovery verifies bridge after reload", async () => {
+  const content = await source();
+  // Must call bridgeExists() after reload, not assume reload's exit code
+  // means the bridge came back (it doesn't, in the failure mode we saw).
+  const reloadIdx = content.indexOf('"reload", "--all"');
+  assert(reloadIdx >= 0, "reload --all call must exist");
+  const after = content.slice(reloadIdx);
+  assertStringIncludes(after, "bridgeExists(");
+});
+
+Deno.test("daemon bridge recovery has rm + create fallback", async () => {
+  const content = await source();
+  // Match the structural shape without depending on deno fmt's wrapping
+  // (it splits multi-element arrays across lines).
+  assertStringIncludes(content, '"network", "rm"');
+  assertStringIncludes(content, "buildCreateArgs(");
+  assertStringIncludes(content, '"create"');
+});
+
+Deno.test("daemon bridge recovery refuses when containers attached", async () => {
+  const content = await source();
+  // The presence of an attached-containers check + an early return when
+  // the list is non-empty. Loose string match — looking for the guard
+  // shape rather than exact wording.
+  assertStringIncludes(content, "listAttachedContainers");
+  assertStringIncludes(content, "attached.length > 0");
+});
+
+Deno.test("daemon bridge recovery refuses docker recreate (CLI-only)", async () => {
+  const content = await source();
+  // Docker recreate needs engine-specific options we can't always extract
+  // from inspect output. The daemon must point the user at the CLI's
+  // `jiji network setup`, not silently recreate with the wrong options.
+  assertStringIncludes(content, 'engine === "docker"');
+  assertStringIncludes(content, "jiji network setup");
+});

--- a/packages/daemon/tests/peer_cache_test.ts
+++ b/packages/daemon/tests/peer_cache_test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the on-disk peer cache.
+ *
+ * The cache exists to break the chicken-and-egg between WireGuard and
+ * Corrosion at daemon startup. These tests cover the file-format end:
+ * round-trip serialization, atomic-write semantics, and graceful handling
+ * of missing/malformed/future-version files.
+ *
+ * `hydrateFromCache` itself isn't unit-tested here because it shells out
+ * to `wg`. Its file-loading half is exercised through `loadCache`.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { loadCache, saveCache } from "../src/peer_cache.ts";
+import type { CachedPeer } from "../src/peer_cache.ts";
+
+async function tempPath(): Promise<string> {
+  const dir = await Deno.makeTempDir({ prefix: "jiji-peer-cache-test-" });
+  return `${dir}/peers.json`;
+}
+
+const samplePeer: CachedPeer = {
+  publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+  allowedIps: "10.210.1.0/24,10.210.129.0/24,fdb1::1/128",
+  endpoints: ["1.2.3.4:31820", "192.168.1.220:31820"],
+  persistentKeepalive: 25,
+};
+
+Deno.test("saveCache then loadCache round-trips peers", async () => {
+  const path = await tempPath();
+  try {
+    await saveCache(path, [samplePeer]);
+    const loaded = await loadCache(path);
+    assert(loaded, "loadCache returned null after a fresh save");
+    assertEquals(loaded.version, 1);
+    assertEquals(loaded.peers, [samplePeer]);
+    assert(loaded.updatedAt > 0, "updatedAt should be set");
+  } finally {
+    await Deno.remove(path, { recursive: false }).catch(() => {});
+  }
+});
+
+Deno.test("saveCache creates parent directories", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "jiji-peer-cache-test-" });
+  const path = `${dir}/nested/deep/peers.json`;
+  try {
+    await saveCache(path, [samplePeer]);
+    const stat = await Deno.stat(path);
+    assert(stat.isFile, "expected the cache file to exist");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("saveCache writes atomically (no .tmp residue on success)", async () => {
+  const path = await tempPath();
+  try {
+    await saveCache(path, [samplePeer]);
+    // The atomic-write path uses `<path>.tmp` then renames over the target.
+    // A successful save must not leave the .tmp around.
+    const tmpExists = await Deno.stat(`${path}.tmp`).then(() => true).catch(
+      () => false,
+    );
+    assertEquals(tmpExists, false, "stale .tmp left after successful save");
+  } finally {
+    await Deno.remove(path).catch(() => {});
+  }
+});
+
+Deno.test("loadCache returns null when file is missing", async () => {
+  const result = await loadCache("/nonexistent/jiji/peers.json");
+  assertEquals(result, null);
+});
+
+Deno.test("loadCache returns null for malformed JSON", async () => {
+  const path = await tempPath();
+  try {
+    await Deno.writeTextFile(path, "{not valid json");
+    const result = await loadCache(path);
+    assertEquals(result, null);
+  } finally {
+    await Deno.remove(path).catch(() => {});
+  }
+});
+
+Deno.test("loadCache returns null when shape doesn't match", async () => {
+  const path = await tempPath();
+  try {
+    // Valid JSON, wrong shape — missing `peers` array.
+    await Deno.writeTextFile(
+      path,
+      JSON.stringify({ version: 1, updatedAt: 0 }),
+    );
+    assertEquals(await loadCache(path), null);
+
+    // peers entry missing required fields.
+    await Deno.writeTextFile(
+      path,
+      JSON.stringify({
+        version: 1,
+        updatedAt: 0,
+        peers: [{ publicKey: "x" }],
+      }),
+    );
+    assertEquals(await loadCache(path), null);
+  } finally {
+    await Deno.remove(path).catch(() => {});
+  }
+});
+
+Deno.test("loadCache refuses future schema versions", async () => {
+  const path = await tempPath();
+  try {
+    // A forward-compatible read could silently accept fields it doesn't
+    // understand and corrupt state. We'd rather log + fall through to
+    // "no cache" and let the running daemon rebuild it.
+    await Deno.writeTextFile(
+      path,
+      JSON.stringify({ version: 999, updatedAt: 0, peers: [] }),
+    );
+    assertEquals(await loadCache(path), null);
+  } finally {
+    await Deno.remove(path).catch(() => {});
+  }
+});
+
+Deno.test("saveCache overwrites previous content", async () => {
+  const path = await tempPath();
+  try {
+    await saveCache(path, [samplePeer]);
+    await saveCache(path, []);
+    const loaded = await loadCache(path);
+    assert(loaded);
+    assertEquals(loaded.peers, []);
+  } finally {
+    await Deno.remove(path).catch(() => {});
+  }
+});

--- a/packages/daemon/tests/split_brain_heal_test.ts
+++ b/packages/daemon/tests/split_brain_heal_test.ts
@@ -38,7 +38,7 @@ Deno.test("healSplitBrain uses cached endpoints, not Corrosion", async () => {
   assert(
     !fnSection.includes("CorrosionCli") &&
       !fnSection.includes("CorrosionClient") &&
-      !fnSection.includes("from \"./corrosion"),
+      !fnSection.includes('from "./corrosion'),
     "healSplitBrain must not depend on Corrosion (it's the broken thing)",
   );
 });

--- a/packages/daemon/tests/split_brain_heal_test.ts
+++ b/packages/daemon/tests/split_brain_heal_test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression tests for split-brain healing.
+ *
+ * `healSplitBrain` shells out to `wg`, so we can't meaningfully unit-test
+ * its behaviour without mocking the WireGuard subprocess. Instead we
+ * pin the invariants that make the heal actually heal:
+ *
+ *   - Heal exists, is exported, and lives in peer_cache.ts (so it uses
+ *     the same cache file the boot hydrate writes).
+ *   - Heal is wired into the main loop, gated by isSplitBrainDetected().
+ *   - The wiring runs every iteration, not only on the SPLIT_BRAIN_INTERVAL
+ *     boundary — the flag is sticky, and we want a ~30s heal cadence.
+ *   - Heal sources endpoints from the cache, not from Corrosion, because
+ *     Corrosion is the thing that's broken during a partition.
+ *   - Heal respects PEER_DOWN_THRESHOLD so we don't flap endpoints on a
+ *     peer that just hasn't handshaked yet.
+ */
+
+import { assert, assertStringIncludes } from "@std/assert";
+
+Deno.test("healSplitBrain is exported from peer_cache.ts", async () => {
+  const content = await Deno.readTextFile("src/peer_cache.ts");
+  assertStringIncludes(content, "export async function healSplitBrain");
+});
+
+Deno.test("healSplitBrain uses cached endpoints, not Corrosion", async () => {
+  const content = await Deno.readTextFile("src/peer_cache.ts");
+  const fnStart = content.indexOf("export async function healSplitBrain");
+  assert(fnStart >= 0);
+  // Take a generous slice — heal body is around 80 lines.
+  const fnSection = content.slice(fnStart, fnStart + 4000);
+
+  // Must use the cache file (loadCache) as the source of truth.
+  assertStringIncludes(fnSection, "loadCache(cachePath)");
+
+  // Must rotate using cached endpoints array, not anything Corrosion-related.
+  // Guards against a regression that reaches back into Corrosion.
+  assert(
+    !fnSection.includes("CorrosionCli") &&
+      !fnSection.includes("CorrosionClient") &&
+      !fnSection.includes("from \"./corrosion"),
+    "healSplitBrain must not depend on Corrosion (it's the broken thing)",
+  );
+});
+
+Deno.test("healSplitBrain respects PEER_DOWN_THRESHOLD", async () => {
+  const content = await Deno.readTextFile("src/peer_cache.ts");
+  const fnStart = content.indexOf("export async function healSplitBrain");
+  const fnSection = content.slice(fnStart, fnStart + 4000);
+  assertStringIncludes(fnSection, "PEER_DOWN_THRESHOLD");
+});
+
+Deno.test("main loop runs heal every iteration when flag is set", async () => {
+  const content = await Deno.readTextFile("src/main.ts");
+  // The detection call is interval-gated; the heal call must NOT be.
+  const detectIdx = content.indexOf("detectSplitBrain(config, cli)");
+  const healIdx = content.indexOf("healSplitBrain(");
+  assert(detectIdx >= 0, "detectSplitBrain wiring missing");
+  assert(healIdx >= 0, "healSplitBrain wiring missing in main loop");
+
+  // The block immediately preceding healSplitBrain must check
+  // isSplitBrainDetected(), not the interval modulus, so the heal runs
+  // every loop tick instead of only at the detection boundary.
+  const preHeal = content.slice(Math.max(0, healIdx - 200), healIdx);
+  assertStringIncludes(preHeal, "isSplitBrainDetected()");
+  assert(
+    !preHeal.includes("% SPLIT_BRAIN_INTERVAL"),
+    "heal must not be gated by SPLIT_BRAIN_INTERVAL (flag is sticky)",
+  );
+});
+
+Deno.test("main loop imports both detection flag and heal", async () => {
+  const content = await Deno.readTextFile("src/main.ts");
+  assertStringIncludes(content, "isSplitBrainDetected");
+  assertStringIncludes(content, "healSplitBrain");
+});

--- a/packages/daemon/tests/tombstone_test.ts
+++ b/packages/daemon/tests/tombstone_test.ts
@@ -1,0 +1,100 @@
+/**
+ * Schema-level regression tests for tombstone-aware reconciliation.
+ *
+ * These read source files and assert on key substrings, matching the
+ * existing test pattern in this package. The point is to catch regressions
+ * where someone adds (or reverts) reconciliation logic without preserving
+ * the rules that prevent split-brain peer eviction:
+ *
+ *   1. The reconciler only treats a non-null `removed_at` as evidence to
+ *      remove a peer. Absence from the active set is NEVER a removal signal.
+ *   2. The reconciler must not filter peer candidates by `last_seen` —
+ *      that turned brief outages into permanent mesh tears.
+ *   3. The GC and split-brain detector must skip tombstoned rows so an
+ *      explicitly-decommissioned server doesn't trigger spurious alerts or
+ *      offline-server cleanup logic.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+Deno.test("peer_reconciler reads non-tombstoned peer servers", async () => {
+  const content = await Deno.readTextFile("src/peer_reconciler.ts");
+  const fnStart = content.indexOf("async function getPeerServers");
+  assertEquals(
+    fnStart >= 0,
+    true,
+    "getPeerServers helper must exist",
+  );
+  const fnSection = content.slice(fnStart, fnStart + 600);
+  assertStringIncludes(fnSection, "removed_at IS NULL");
+  // No last_seen filter — a temporarily-offline peer must remain a WG peer
+  // so gossip can resume when it returns. This was the original bug.
+  assertEquals(
+    fnSection.includes("last_seen"),
+    false,
+    "getPeerServers must not filter on last_seen (caused split-brain)",
+  );
+});
+
+Deno.test("peer_reconciler reads tombstoned pubkeys for explicit removal", async () => {
+  const content = await Deno.readTextFile("src/peer_reconciler.ts");
+  const fnStart = content.indexOf("async function getTombstonedPubkeys");
+  assertEquals(
+    fnStart >= 0,
+    true,
+    "getTombstonedPubkeys helper must exist",
+  );
+  const fnSection = content.slice(fnStart, fnStart + 400);
+  assertStringIncludes(fnSection, "removed_at IS NOT NULL");
+});
+
+Deno.test("peer_reconciler removes peers only via positive tombstone evidence", async () => {
+  const content = await Deno.readTextFile("src/peer_reconciler.ts");
+  // The reconcile loop must only call wg.removePeer when the pubkey is in
+  // the tombstoned set. Guard against a regression to absence-based removal.
+  assertStringIncludes(content, "tombstonedPubkeys.has(peer.publicKey)");
+  assertEquals(
+    content.includes("activePubkeys.has"),
+    false,
+    "Reconciler must not key peer removal on the active-peer set (split-brain bug)",
+  );
+});
+
+Deno.test("garbage_collector immediately deletes tombstoned-server containers", async () => {
+  const content = await Deno.readTextFile("src/garbage_collector.ts");
+  const fnStart = content.indexOf(
+    "async function deleteTombstonedServerContainers",
+  );
+  assertEquals(
+    fnStart >= 0,
+    true,
+    "deleteTombstonedServerContainers helper must exist",
+  );
+  const fnSection = content.slice(fnStart, fnStart + 600);
+  assertStringIncludes(fnSection, "removed_at IS NOT NULL");
+});
+
+Deno.test("garbage_collector offline-server cleanup skips tombstoned rows", async () => {
+  const content = await Deno.readTextFile("src/garbage_collector.ts");
+  const fnStart = content.indexOf(
+    "async function deleteOfflineServerContainers",
+  );
+  const fnSection = content.slice(fnStart, fnStart + 600);
+  // Offline cleanup uses a stale-heartbeat threshold. It must not also fire
+  // on tombstoned servers — those are handled by the dedicated path above,
+  // and we don't want the GC double-counting them.
+  assertStringIncludes(fnSection, "removed_at IS NULL");
+});
+
+Deno.test("split_brain counts ignore tombstoned servers", async () => {
+  const content = await Deno.readTextFile("src/split_brain.ts");
+  // Both totals (total servers, active servers, unreachable list) must
+  // exclude tombstoned rows. Otherwise a decommissioned server permanently
+  // skews the active/total ratio toward a false split-brain alert.
+  const matches = content.match(/removed_at IS NULL/g) ?? [];
+  assertEquals(
+    matches.length >= 3,
+    true,
+    `expected >= 3 'removed_at IS NULL' guards in split_brain.ts, got ${matches.length}`,
+  );
+});

--- a/packages/daemon/tests/types_test.ts
+++ b/packages/daemon/tests/types_test.ts
@@ -25,6 +25,7 @@ Deno.test("parseConfig - uses defaults when only JIJI_SERVER_ID set", () => {
     JIJI_CORROSION_API: Deno.env.get("JIJI_CORROSION_API"),
     JIJI_CORROSION_DIR: Deno.env.get("JIJI_CORROSION_DIR"),
     JIJI_LOOP_INTERVAL: Deno.env.get("JIJI_LOOP_INTERVAL"),
+    JIJI_PEER_CACHE: Deno.env.get("JIJI_PEER_CACHE"),
   };
 
   // Set only JIJI_SERVER_ID, clear others
@@ -34,6 +35,7 @@ Deno.test("parseConfig - uses defaults when only JIJI_SERVER_ID set", () => {
   Deno.env.delete("JIJI_CORROSION_API");
   Deno.env.delete("JIJI_CORROSION_DIR");
   Deno.env.delete("JIJI_LOOP_INTERVAL");
+  Deno.env.delete("JIJI_PEER_CACHE");
 
   try {
     const config = parseConfig();
@@ -43,6 +45,7 @@ Deno.test("parseConfig - uses defaults when only JIJI_SERVER_ID set", () => {
     assertEquals(config.corrosionApi, "http://127.0.0.1:31220");
     assertEquals(config.corrosionDir, "/opt/jiji/corrosion");
     assertEquals(config.loopInterval, 30);
+    assertEquals(config.peerCachePath, "/var/lib/jiji/peers.json");
   } finally {
     // Restore
     for (const [key, val] of Object.entries(original)) {
@@ -106,6 +109,7 @@ Deno.test("parseConfig - accepts custom values", () => {
     JIJI_CORROSION_API: Deno.env.get("JIJI_CORROSION_API"),
     JIJI_CORROSION_DIR: Deno.env.get("JIJI_CORROSION_DIR"),
     JIJI_LOOP_INTERVAL: Deno.env.get("JIJI_LOOP_INTERVAL"),
+    JIJI_PEER_CACHE: Deno.env.get("JIJI_PEER_CACHE"),
   };
 
   Deno.env.set("JIJI_SERVER_ID", "custom-server");
@@ -114,6 +118,7 @@ Deno.test("parseConfig - accepts custom values", () => {
   Deno.env.set("JIJI_CORROSION_API", "http://10.0.0.1:31220");
   Deno.env.set("JIJI_CORROSION_DIR", "/custom/path");
   Deno.env.set("JIJI_LOOP_INTERVAL", "60");
+  Deno.env.set("JIJI_PEER_CACHE", "/run/jiji/peers.json");
 
   try {
     const config = parseConfig();
@@ -123,6 +128,7 @@ Deno.test("parseConfig - accepts custom values", () => {
     assertEquals(config.corrosionApi, "http://10.0.0.1:31220");
     assertEquals(config.corrosionDir, "/custom/path");
     assertEquals(config.loopInterval, 60);
+    assertEquals(config.peerCachePath, "/run/jiji/peers.json");
   } finally {
     for (const [key, val] of Object.entries(original)) {
       if (val !== undefined) Deno.env.set(key, val);


### PR DESCRIPTION
## Summary

Four stacked improvements so reboots and gossip partitions no longer require running `jiji network setup` out-of-band to recover. Each commit is independently reviewable.

- **`feat(network): tombstone-based peer removal in Corrosion`** — adds `servers.removed_at`, switches the daemon reconciler to remove WireGuard peers only on positive tombstone evidence (never on absence from the active set), adds `jiji network server remove <id>`.
- **`feat(daemon): seed WireGuard from on-disk peer cache at boot`** — daemon writes `/var/lib/jiji/peers.json` after each successful reconcile and hydrates WG from it at startup before the main loop. Breaks the chicken-and-egg between Corrosion gossip and the WG mesh.
- **`feat(daemon): heal split-brain from on-disk peer cache`** — `detectSplitBrain` no longer just flips a flag. While the flag is set, `healSplitBrain` runs every loop tick, re-adding missing peers and rotating endpoints from the cache (since Corrosion is the broken thing during a partition).
- **`fix(network): recover missing container-network bridge robustly`** — strengthens the `podman1` bridge recovery path on both CLI setup and daemon. No more silent `reload --all 2>/dev/null || true`; verifies the bridge actually came back, and falls back to rm + create when no containers are attached.

## Why these are together

#3 imports from #2 (heal lives in `peer_cache.ts`), and #1 + #2 share a rollout — one `jiji network setup` refreshes both the schema migration and the daemon systemd unit. Feature-by-feature history is preserved as four commits.

## Rollout

1. `jiji network setup` against each cluster — applies the `removed_at` column migration and refreshes the systemd unit to pick up `StateDirectory=jiji` + `JIJI_PEER_CACHE`.
2. Roll the new daemon binary.

Order matters: new daemon against old schema would fail on `removed_at IS NULL` queries.

## Test plan

- [x] `mise fmt` clean
- [x] `mise lint` clean
- [x] `mise test` — CLI 836, DNS 31, daemon 78 (all pass)
- [x] `mise build` — all 3 binaries
- [ ] On real cluster: take a node offline > 5 min, confirm its WG peer survives (was the original bug). Tombstone via `jiji network server remove <id>`, confirm peer disappears within ~30s.
- [ ] On real cluster: reboot a node, confirm daemon hydrates from `/var/lib/jiji/peers.json` and rejoins gossip before the first reconcile cycle.
- [ ] On real cluster: `podman network rm jiji` then wait for daemon to recover; confirm bridge comes back without manual `jiji network setup`.
