### PR TITLE
fix(release): stop release-please version-bump loop

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,9 +2,9 @@
   "crates/jiji-cli": "0.5.1",
   "crates/jiji-agent": "0.5.1",
   "crates/jiji-proxy": "0.5.0",
-  "crates/jiji-core": "0.6.0",
-  "crates/jiji-tui": "0.6.0",
-  "crates/jiji-config": "0.6.0",
-  "crates/jiji-network": "0.6.0",
-  "crates/jiji-ssh": "0.6.0"
+  "crates/jiji-core": "0.5.0",
+  "crates/jiji-tui": "0.5.0",
+  "crates/jiji-config": "0.5.0",
+  "crates/jiji-network": "0.5.0",
+  "crates/jiji-ssh": "0.5.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,17 +271,29 @@ own `packages` config). Tracked by
 version, no manual bump command; never hand-edit a crate's `version` or
 the manifest outside a release-please PR.
 
-`jiji`, `jiji-agent`, `jiji-proxy` are the only *publicly* released
-crates: independent tags (`vX.Y.Z` / `jiji-agent-vX.Y.Z` /
-`jiji-proxy-vX.Y.Z`), GitHub Release, and build/publish workflow
-(`jiji-release.yml`, `jiji-agent-release.yml`, `jiji-proxy-release.yml`)
-per crate. The 5 internal-only crates are release-please packages too but
-`"skip-github-release": true`: real version bump + `CHANGELOG.md` entry,
-no tag/public release. That's what makes internal-crate changes count:
-`cargo-workspace` patch-bumps every crate that depends on whatever just
-bumped, so a `fix:` to `jiji-core` cascades through `jiji-network` into
-`jiji-cli`/`jiji-agent`, no `Release-As:` footer needed. `jiji-proxy` has
-no internal deps, so nothing cascades into it.
+All 8 crates get an independent tag (`vX.Y.Z` for `jiji`, `{package}-vX.Y.Z`
+for the other 7) and a GitHub Release, but only `jiji`, `jiji-agent`, and
+`jiji-proxy` have a build/publish workflow attached to that tag
+(`jiji-release.yml`, `jiji-agent-release.yml`, `jiji-proxy-release.yml`).
+The other 5 are internal-only: their tag/release exists purely so
+release-please has an anchor for that package (see the loop gotcha below),
+not because anyone should consume them directly. `cargo-workspace`
+patch-bumps every crate that depends on whatever just bumped, so a `fix:`
+to `jiji-core` cascades through `jiji-network` into `jiji-cli`/`jiji-agent`,
+no `Release-As:` footer needed. `jiji-proxy` has no internal deps, so
+nothing cascades into it.
+
+**Gotcha (confirmed live, don't reintroduce):** a package configured with
+`"skip-github-release": true` gets no tag at all, not just no public
+Release page. Without a tag, release-please has no anchor to tell it that
+package was already released, so on every subsequent run it re-surfaces the
+*original* triggering commit and bumps that package again, forever,
+cascading an empty-changelog patch bump onto every real-tagged dependent
+too (confirmed live: this looped through 3 auto-generated release PRs,
+each re-citing the same commit, before being caught). Every package in
+`release-please-config.json` must get a real tag, even the internal-only
+ones; use the build/publish workflow's presence, not `skip-github-release`,
+to distinguish "consumable" from "internal-only."
 
 **Gotcha (confirmed live, don't reintroduce):** internal
 `[workspace.dependencies]` entries must stay bare `{ path = "..." }`, no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "jiji-config"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "jiji-core",
  "serde",
@@ -2137,14 +2137,14 @@ dependencies = [
 
 [[package]]
 name = "jiji-core"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "jiji-network"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "jiji-config",
  "jiji-core",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "jiji-ssh"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "rand 0.10.2",
  "russh",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "jiji-tui"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "dialoguer",
  "indicatif",

--- a/crates/jiji-config/CHANGELOG.md
+++ b/crates/jiji-config/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [0.6.0](https://github.com/acidtib/jiji/compare/jiji-config-v0.5.0...jiji-config-v0.6.0) (2026-08-08)
-
-
-### Features
-
-* rewrite jiji in Rust with agent-based control plane ([#66](https://github.com/acidtib/jiji/issues/66)) ([f7a1984](https://github.com/acidtib/jiji/commit/f7a19848954c3a3e6e33f154d9a3abc870ceb2ce))
-
 ## [0.5.0](https://github.com/acidtib/jiji/compare/jiji-config-v0.4.9...jiji-config-v0.5.0) (2026-08-08)
 
 

--- a/crates/jiji-config/Cargo.toml
+++ b/crates/jiji-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jiji-config"
-version = "0.6.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/jiji-core/CHANGELOG.md
+++ b/crates/jiji-core/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [0.6.0](https://github.com/acidtib/jiji/compare/jiji-core-v0.5.0...jiji-core-v0.6.0) (2026-08-08)
-
-
-### Features
-
-* rewrite jiji in Rust with agent-based control plane ([#66](https://github.com/acidtib/jiji/issues/66)) ([f7a1984](https://github.com/acidtib/jiji/commit/f7a19848954c3a3e6e33f154d9a3abc870ceb2ce))
-
 ## [0.5.0](https://github.com/acidtib/jiji/compare/jiji-core-v0.4.9...jiji-core-v0.5.0) (2026-08-08)
 
 

--- a/crates/jiji-core/Cargo.toml
+++ b/crates/jiji-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jiji-core"
-version = "0.6.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/jiji-network/CHANGELOG.md
+++ b/crates/jiji-network/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [0.6.0](https://github.com/acidtib/jiji/compare/jiji-network-v0.5.0...jiji-network-v0.6.0) (2026-08-08)
-
-
-### Features
-
-* rewrite jiji in Rust with agent-based control plane ([#66](https://github.com/acidtib/jiji/issues/66)) ([f7a1984](https://github.com/acidtib/jiji/commit/f7a19848954c3a3e6e33f154d9a3abc870ceb2ce))
-
 ## [0.5.0](https://github.com/acidtib/jiji/compare/jiji-network-v0.4.9...jiji-network-v0.5.0) (2026-08-08)
 
 

--- a/crates/jiji-network/Cargo.toml
+++ b/crates/jiji-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jiji-network"
-version = "0.6.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/jiji-ssh/CHANGELOG.md
+++ b/crates/jiji-ssh/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [0.6.0](https://github.com/acidtib/jiji/compare/jiji-ssh-v0.5.0...jiji-ssh-v0.6.0) (2026-08-08)
-
-
-### Features
-
-* rewrite jiji in Rust with agent-based control plane ([#66](https://github.com/acidtib/jiji/issues/66)) ([f7a1984](https://github.com/acidtib/jiji/commit/f7a19848954c3a3e6e33f154d9a3abc870ceb2ce))
-
 ## [0.5.0](https://github.com/acidtib/jiji/compare/jiji-ssh-v0.4.9...jiji-ssh-v0.5.0) (2026-08-08)
 
 

--- a/crates/jiji-ssh/Cargo.toml
+++ b/crates/jiji-ssh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jiji-ssh"
-version = "0.6.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/jiji-tui/CHANGELOG.md
+++ b/crates/jiji-tui/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [0.6.0](https://github.com/acidtib/jiji/compare/jiji-tui-v0.5.0...jiji-tui-v0.6.0) (2026-08-08)
-
-
-### Features
-
-* rewrite jiji in Rust with agent-based control plane ([#66](https://github.com/acidtib/jiji/issues/66)) ([f7a1984](https://github.com/acidtib/jiji/commit/f7a19848954c3a3e6e33f154d9a3abc870ceb2ce))
-
 ## [0.5.0](https://github.com/acidtib/jiji/compare/jiji-tui-v0.4.9...jiji-tui-v0.5.0) (2026-08-08)
 
 

--- a/crates/jiji-tui/Cargo.toml
+++ b/crates/jiji-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jiji-tui"
-version = "0.6.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,27 +26,37 @@
     "crates/jiji-core": {
       "release-type": "rust",
       "package-name": "jiji-core",
-      "skip-github-release": true
+      "component": "jiji-core",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
     },
     "crates/jiji-tui": {
       "release-type": "rust",
       "package-name": "jiji-tui",
-      "skip-github-release": true
+      "component": "jiji-tui",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
     },
     "crates/jiji-config": {
       "release-type": "rust",
       "package-name": "jiji-config",
-      "skip-github-release": true
+      "component": "jiji-config",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
     },
     "crates/jiji-network": {
       "release-type": "rust",
       "package-name": "jiji-network",
-      "skip-github-release": true
+      "component": "jiji-network",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
     },
     "crates/jiji-ssh": {
       "release-type": "rust",
       "package-name": "jiji-ssh",
-      "skip-github-release": true
+      "component": "jiji-ssh",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
     }
   }
 }


### PR DESCRIPTION
## Summary
- `skip-github-release: true` on jiji-core/jiji-config/jiji-network/jiji-ssh/jiji-tui also skips tag creation, so release-please had no anchor for those 5 packages and kept re-surfacing the original #66 commit on every run, cascading an empty patch bump onto jiji-agent/jiji-cli too. This produced PR #70 and PR #71 (closed), each re-bumping and re-citing the same commit.
- Removes `skip-github-release` from those 5 packages so they get real tags (`{package}-vX.Y.Z`) going forward, same as jiji-agent/jiji-proxy already do. They still have no build/publish workflow attached to their tags, only jiji/jiji-agent/jiji-proxy do, so this doesn't change what gets published anywhere.
- Reverts the bogus `0.6.0` version/changelog entries PR #70 introduced for those 5 packages back to the real `0.5.0` release. jiji-agent and jiji-cli stay at `0.5.1` since those tags/GitHub Releases were already published publicly before the loop was caught.
- Documents the failure mode in AGENTS.md's Version Management section so it isn't reintroduced.

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo fmt --check` passes
- [x] Verified via `gh release list` / `git tag -l` that jiji-core/jiji-config/jiji-network/jiji-ssh/jiji-tui never had a tag, confirming the root cause
- [ ] After merge, release-please's next run is expected to open one more small release PR bumping just these 5 packages 0.5.0 -> 0.5.1 (attributing this fix commit) and this time create real tags for them, permanently closing the loop