### PR TITLE
fix(ci): use a PAT for release-please so build workflows trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,5 +18,13 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          # A PAT is required here: tags/releases created with the default
+          # GITHUB_TOKEN never trigger other workflows (GitHub's anti-recursion
+          # protection), which is why jiji-release.yml/jiji-agent-release.yml/
+          # jiji-proxy-release.yml never ran on any past tag. Falls back to
+          # GITHUB_TOKEN if the secret isn't configured, which keeps this
+          # workflow itself working (PR creation, tagging) but reproduces the
+          # same no-downstream-trigger gap until the secret is set.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Tags/releases created by release-please via the default `GITHUB_TOKEN` never trigger other GitHub Actions workflows (GitHub's built-in anti-recursion protection). Confirmed via `gh run list`: `jiji-release.yml`, `jiji-agent-release.yml`, and `jiji-proxy-release.yml` have zero runs ever, despite tags going back to `v0.4.1`, no binaries have ever actually been built for a release.
- Passes `secrets.RELEASE_PLEASE_TOKEN` (a fine-grained PAT scoped to this repo, just added) to the `release-please-action` step instead, so future tags it creates will properly trigger those build workflows. Falls back to `GITHUB_TOKEN` if the secret is ever removed, so this doesn't break the release-please workflow itself either way.

## Test plan
- [ ] After merge, the next release-please-driven tag push should trigger the matching `*-release.yml` build workflow (verify via `gh run list --workflow=jiji-release.yml` etc. after the next release)