### PR TITLE
fix(ci): allow manually dispatching the binary/image release workflows

### DIFF
--- a/.github/workflows/jiji-agent-release.yml
+++ b/.github/workflows/jiji-agent-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "jiji-agent-v*"
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/jiji-proxy-release.yml
+++ b/.github/workflows/jiji-proxy-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "jiji-proxy-v*"
+  workflow_dispatch:
 
 env:
   IMAGE: ghcr.io/acidtib/jiji-proxy

--- a/.github/workflows/jiji-release.yml
+++ b/.github/workflows/jiji-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch:` to `jiji-release.yml`, `jiji-agent-release.yml`, and `jiji-proxy-release.yml` alongside their existing tag-push triggers.
- Lets us backfill the binaries/images for releases that were tagged before #74's PAT fix landed (`v0.5.2`, `jiji-agent-v0.5.2`, `jiji-proxy-v0.5.0` currently have no build artifacts) by running the workflow with "Use workflow from" set to that tag, without needing to re-tag anything.
- No logic changes: dispatching against a tag ref makes `GITHUB_REF`/checkout resolve exactly as if that tag were pushed, so the existing version-parsing and release-upload steps work unchanged.

## Test plan
- [ ] After merge, dispatch each workflow against its outstanding untagged-binary release and confirm binaries/images actually get attached this time