### PR TITLE
fix(ci): make workflow_dispatch actually usable to backfill old tags

### DIFF
--- a/.github/workflows/jiji-agent-release.yml
+++ b/.github/workflows/jiji-agent-release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "jiji-agent-v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)build and attach binaries to, e.g. jiji-agent-v0.5.2"
+        required: true
 
 jobs:
   test:
@@ -26,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -63,11 +69,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
 
       - name: Get tag version
         id: get_tag_version
-        run: echo "TAG_VERSION=${GITHUB_REF/refs\/tags\/jiji-agent-v/}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "TAG_VERSION=${TAG#jiji-agent-v}" >> "$GITHUB_OUTPUT"
 
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/jiji-proxy-release.yml
+++ b/.github/workflows/jiji-proxy-release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "jiji-proxy-v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)build and push the image for, e.g. jiji-proxy-v0.5.0"
+        required: true
 
 env:
   IMAGE: ghcr.io/acidtib/jiji-proxy
@@ -32,10 +36,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Get tag version
         id: get_tag_version
-        run: echo "TAG_VERSION=${GITHUB_REF/refs\/tags\/jiji-proxy-v/}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "TAG_VERSION=${TAG#jiji-proxy-v}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -68,7 +76,9 @@ jobs:
     steps:
       - name: Get tag version
         id: get_tag_version
-        run: echo "TAG_VERSION=${GITHUB_REF/refs\/tags\/jiji-proxy-v/}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "TAG_VERSION=${TAG#jiji-proxy-v}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/jiji-release.yml
+++ b/.github/workflows/jiji-release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)build and attach binaries to, e.g. v0.5.2"
+        required: true
 
 jobs:
   test:
@@ -32,6 +36,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -66,11 +72,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
 
       - name: Get tag version
         id: get_tag_version
-        run: echo "TAG_VERSION=${GITHUB_REF/refs\/tags\/v/}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "TAG_VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Download artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary
- #75 added a bare `workflow_dispatch:` trigger, but dispatching with `--ref <tag>` requires *that tag's own copy* of the workflow file to already declare the trigger, so it only works for tags created after #75 merged, not for backfilling `v0.5.2`/`jiji-agent-v0.5.2`/`jiji-proxy-v0.5.0` (confirmed: `gh workflow run jiji-release.yml --ref v0.5.2` fails with `Workflow does not have 'workflow_dispatch' trigger`).
- Adds an explicit `tag` input instead. Now you dispatch from `main` (which has the trigger), and every checkout/version-parsing step uses the input tag when present, falling back to `github.ref`/`github.ref_name` for the normal tag-push case so nothing changes for the existing flow.

## Test plan
- [ ] After merge, `gh workflow run jiji-release.yml -f tag=v0.5.2`, `gh workflow run jiji-agent-release.yml -f tag=jiji-agent-v0.5.2`, and `gh workflow run jiji-proxy-release.yml -f tag=jiji-proxy-v0.5.0` should each run to completion and attach binaries/push the image to the already-existing releases