### PR TITLE
fix(ci): add missing trailing newline in changelog expansion script

### DIFF
--- a/.github/scripts/expand-dependency-changelog.sh
+++ b/.github/scripts/expand-dependency-changelog.sh
@@ -46,5 +46,10 @@ for dep in $deps; do
 done
 
 if [ -n "$sections" ]; then
-  printf '\n### Crate changes in this release\n%s' "$sections"
+  # Trailing newline is required: this output is captured between two
+  # delimiter lines in a GITHUB_OUTPUT heredoc block by every caller. Without
+  # it, the closing delimiter gets appended to this output's last line
+  # instead of starting its own line, and GitHub's parser fails with
+  # "Matching delimiter not found" (confirmed live).
+  printf '\n### Crate changes in this release\n%s\n' "$sections"
 fi


### PR DESCRIPTION
## Summary
- `expand-dependency-changelog.sh`'s final `printf` had no trailing newline when it had a "Crate changes" section to append (both `sections+=$(...)` and the final `printf` strip/omit the trailing `\n`).
- Every caller (`jiji-release.yml`, `jiji-agent-release.yml`) captures this output between two delimiter lines in a `GITHUB_OUTPUT` heredoc block. Without the trailing newline, the closing delimiter gets appended onto the script's last output line instead of starting its own line, so GitHub's parser fails with `Invalid value. Matching delimiter not found`.
- This is the first time this script has ever actually run in CI with a real local-dependency bump to report (the release workflows never ran at all until #74/#76), so it's a genuinely new, previously-undiscovered bug, not a regression.
- Reproduced locally against the exact `jiji-agent-v0.5.2` commit/changelog body that failed in CI, confirmed the fix produces a correctly-terminated `GITHUB_OUTPUT` block.

## Test plan
- [x] Reproduced the exact failure locally (checked out `jiji-agent-v0.5.2`, ran the script with the real release body, exit 0 but no trailing newline)
- [x] Verified the fix: output now ends in `\n`, and a simulated `GITHUB_OUTPUT` heredoc block correctly finds the delimiter on its own line
- [x] After merge, re-dispatch `jiji-agent-release.yml -f tag=jiji-agent-v0.5.2` and confirm it completes and attaches binaries