### PR TITLE
fix(ci): stop macos-13 runner queue stalls, fix historical-tag backfill

### DIFF
--- a/.github/workflows/jiji-agent-release.yml
+++ b/.github/workflows/jiji-agent-release.yml
@@ -72,6 +72,14 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
 
+      # When backfilling an old tag, the checkout above reverts this whole
+      # tree, including this script, back to whatever existed at that
+      # historical commit -- confirmed live, this shadowed a bugfix that
+      # only existed on main. Always use main's current copy instead.
+      - name: Use current changelog script
+        if: ${{ inputs.tag != '' }}
+        run: git checkout ${{ github.sha }} -- .github/scripts/expand-dependency-changelog.sh
+
       - name: Get tag version
         id: get_tag_version
         run: |

--- a/.github/workflows/jiji-release.yml
+++ b/.github/workflows/jiji-release.yml
@@ -26,7 +26,11 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             artifact: jiji-linux-arm64
-          - os: macos-13
+          # Cross-compiling to x86_64 on Apple Silicon hardware rather than
+          # using macos-13 (native Intel): confirmed live, macos-13 runners
+          # can queue indefinitely waiting for a runner to be assigned,
+          # while macos-14 gets one immediately.
+          - os: macos-14
             target: x86_64-apple-darwin
             artifact: jiji-macos-x86_64
           - os: macos-14
@@ -74,6 +78,14 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
+
+      # When backfilling an old tag, the checkout above reverts this whole
+      # tree, including this script, back to whatever existed at that
+      # historical commit -- confirmed live, this shadowed a bugfix that
+      # only existed on main. Always use main's current copy instead.
+      - name: Use current changelog script
+        if: ${{ inputs.tag != '' }}
+        run: git checkout ${{ github.sha }} -- .github/scripts/expand-dependency-changelog.sh
 
       - name: Get tag version
         id: get_tag_version


### PR DESCRIPTION
## Summary
- `macos-13` runners can queue indefinitely waiting for assignment (confirmed live: 12+ minutes with no runner picked up, while `macos-14` got one instantly in the same run). Switches the x86_64 cross-compile job to `macos-14`, matching the arm64 job's OS -- it was already cross-compiling via `--target`, not relying on native Intel hardware.
- Dispatching a backfill with `-f tag=<old tag>` checks out that tag's entire tree, including `.github/scripts/expand-dependency-changelog.sh`, silently reverting any fix that only exists on `main`. This shadowed #77's trailing-newline fix when backfilling `jiji-agent-v0.5.2` (confirmed live: it failed again with the identical delimiter error after #77 was already merged). Adds a step that restores the script from the triggering commit (`github.sha`) after a tag-input checkout, so future fixes always apply even when backfilling an older tag.

## Test plan
- [x] After merge, re-dispatch `jiji-agent-release.yml -f tag=jiji-agent-v0.5.2` and confirm it completes and attaches binaries
- [x] Re-run `jiji-release.yml` (push or dispatch) and confirm the macOS x86_64 job gets a runner promptly