### PR TITLE
fix(ci): make release body generation idempotent, don't fail on notify

### DIFF
--- a/.github/workflows/jiji-agent-release.yml
+++ b/.github/workflows/jiji-agent-release.yml
@@ -92,17 +92,18 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Fetch changelog from release-please's release
+      # Reads crates/jiji-agent/CHANGELOG.md directly rather than the GitHub
+      # release's current body: the release body is mutated by this same
+      # job on every run (see "Create GitHub Release" below), so using it
+      # as the starting point is not idempotent -- confirmed live, running
+      # this job twice for the same tag duplicated the whole release body.
+      - name: Extract this release's changelog section
         id: changelog
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_VERSION: ${{ steps.get_tag_version.outputs.TAG_VERSION }}
         run: |
           delimiter="CHANGELOG_EOF_$(openssl rand -hex 8)"
           {
             echo "body<<$delimiter"
-            gh release view "jiji-agent-v$TAG_VERSION" \
-              --repo "${{ github.repository }}" --json body -q .body || true
+            awk '/^## / { n++ } n==1' crates/jiji-agent/CHANGELOG.md
             echo "$delimiter"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/jiji-release.yml
+++ b/.github/workflows/jiji-release.yml
@@ -99,17 +99,18 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Fetch changelog from release-please's release
+      # Reads crates/jiji-cli/CHANGELOG.md directly rather than the GitHub
+      # release's current body: the release body is mutated by this same
+      # job on every run (see "Create GitHub Release" below), so using it
+      # as the starting point is not idempotent -- confirmed live, running
+      # this job twice for the same tag duplicated the whole release body.
+      - name: Extract this release's changelog section
         id: changelog
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_VERSION: ${{ steps.get_tag_version.outputs.TAG_VERSION }}
         run: |
           delimiter="CHANGELOG_EOF_$(openssl rand -hex 8)"
           {
             echo "body<<$delimiter"
-            gh release view "v$TAG_VERSION" \
-              --repo "${{ github.repository }}" --json body -q .body || true
+            awk '/^## / { n++ } n==1' crates/jiji-cli/CHANGELOG.md
             echo "$delimiter"
           } >> "$GITHUB_OUTPUT"
 
@@ -144,7 +145,12 @@ jobs:
             curl -fsSL https://get.jiji.run/install.sh | VERSION=v${{ steps.get_tag_version.outputs.TAG_VERSION }} sh
             ```
 
+      # A courtesy notification, not part of this repo's release: must never
+      # fail the job over it (confirmed live, an expired/misscoped
+      # JIJI_WEBSITE_DISPATCH_TOKEN red-flagged an otherwise fully
+      # successful binary release).
       - name: Notify jiji-website of the new release
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.JIJI_WEBSITE_DISPATCH_TOKEN }}
           TAG_VERSION: ${{ steps.get_tag_version.outputs.TAG_VERSION }}


### PR DESCRIPTION
## Summary
- The "Fetch changelog" step read the GitHub release's *current* body via `gh release view` and fed it through `expand-dependency-changelog.sh`, which re-prints its input then appends fresh content. Since that same body is what this job's own "Create GitHub Release" step writes back, re-running the job for an already-released tag re-appends onto whatever's already there.
- Confirmed live: `v0.5.2`'s release body ended up fully duplicated because the "release" job ran more than once for that tag during today's CI debugging (stuck macOS runner retry, workflow_dispatch backfill attempts, etc).
- Fixed by reading directly from the crate's own `CHANGELOG.md` top section instead (same technique the expand script already uses for dependency crates) -- a fixed, deterministic source that doesn't change no matter how many times the job re-runs. Verified idempotency locally: running the extraction twice against the same historical commit produces byte-identical output.
- Manually corrected `v0.5.2`'s existing release body on GitHub to remove the duplication.
- Also makes the jiji-website notify step `continue-on-error: true` -- a courtesy dispatch to another repo should never fail this repo's own release job (confirmed live: an expired `JIJI_WEBSITE_DISPATCH_TOKEN` did exactly that on an otherwise fully successful release).

## Test plan
- [x] Reproduced the duplication locally against the `v0.5.2` commit, confirmed root cause
- [x] Verified the fix's output is byte-identical across repeated extractions (true idempotency)
- [x] Manually fixed the live `v0.5.2` release body
- [x] Next real release should produce a clean, non-duplicated body regardless of how many times the job needs to retry