### PR TITLE
perf(ci): speed up test suite with nextest and mold linker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,18 @@
+[build]
+incremental = true
+
+# Uncomment to use mold linker (30-40% faster linking for 22 integration binaries).
+# Requires `mold` and `clang` installed: sudo apt-get install mold clang
+# [target.x86_64-unknown-linux-gnu]
+# linker = "clang"
+# rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+#
+# [target.aarch64-unknown-linux-gnu]
+# linker = "clang"
+# rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+# Uncomment to use sccache (caches libsqlite3-sys C compilation, the largest
+# single crate in this workspace due to `rusqlite/bundled`).
+# Requires `cargo install sccache` and `export RUSTC_WRAPPER=sccache`
+# [build]
+# rustc-wrapper = "sccache"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,11 @@
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+# Run test binaries in parallel (nextest default), but keep heavy SSH tests from
+# saturating the runner. Each integration binary spawns full russh servers.
+[test-groups]
+heavy = { max-threads = 4 }
+
+[[profile.default.overrides]]
+filter = "binary(deploy_test) | binary(server_setup_test) | binary(remote_build_test) | binary(server_teardown_test)"
+test-group = "heavy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,14 @@ jobs:
       - name: Lint
         run: cargo clippy --all-targets --all-features
 
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install mold linker
+        uses: rui314/setup-mold@v1
+
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo nextest run --workspace
 
       - name: Build
         run: cargo build --workspace

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,7 +1,10 @@
 [tasks]
 build = "cargo build"
 run = "cargo run --"
-test = "cargo test"
+test = "if command -v cargo-nextest >/dev/null 2>&1; then cargo nextest run --workspace; else cargo test --workspace; fi"
+test-verbose = "if command -v cargo-nextest >/dev/null 2>&1; then cargo nextest run --workspace --no-capture; else cargo test --workspace -- --nocapture; fi"
+test-cli = "if command -v cargo-nextest >/dev/null 2>&1; then cargo nextest run -p jiji-cli; else cargo test -p jiji-cli; fi"
+test-agent = "if command -v cargo-nextest >/dev/null 2>&1; then cargo nextest run -p jiji-agent; else cargo test -p jiji-agent; fi"
 lint = "cargo clippy --all-targets --all-features && cargo fmt --check"
 fmt = "cargo fmt"
 check = "cargo check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,15 @@ russh = "0.62.5"
 ssh2-config = { git = "https://github.com/veeso/ssh2-config", rev = "3a9935222aa98a3374701eae2d283a6af74cdba8" }
 tar = "0.4"
 ignore = "0.4"
+
+[profile.dev]
+split-debuginfo = "unpacked"
+incremental = true
+
+[profile.test]
+inherits = "dev"
+debug = 1
+incremental = true
+
+[profile.dev.package.libsqlite3-sys]
+opt-level = 2


### PR DESCRIPTION
Switch CI/mise from cargo test to cargo nextest, cap concurrency on heavy SSH-mock integration binaries via nextest test-groups, add mold as CI's linker, and tune dev/test cargo profiles (unpacked debuginfo, debug=1 for tests, opt-level=2 for libsqlite3-sys).