### PR TITLE
feat: implement network_mode: host, reject network_mode: none

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,20 +238,20 @@ validation: every service needs a reachable address for DNS and health
 checks, and the one thing `none` is good for (an isolated one-off) is
 already served by `crons:`.
 
-Known gap (not yet fixed): a host-mode container's `jiji.lease` label
-carries `management_address` for observability, the same convention
-`service:<name>` sharing already uses for the upstream's address. Agent-side
-discovery (`recover_labeled_leases` in `jiji-agent/src/discovery.rs`)
-doesn't distinguish this from a genuine per-deployment bridge lease, so it
-tries to claim that label's address as a real lease row keyed by
-`deployment_id`. For `host` mode this produces a permanently-orphaned
-`address_leases` row on every redeploy (cleanup only runs from the bridge
-`AllocateAddress` path, which `host`-mode projects never call) plus a
-recurring "container label conflicts with a durable address lease"
-warning. This bug pattern already existed for `service:<name>` sharing
-before `host` mode was added; fixing it properly needs a way for discovery
-to tell a genuine lease claim apart from an address label kept only for
-observability.
+A container's `jiji.lease` label carries `management_address` for a
+`host`-mode container, or the upstream's address for a `service:<name>`
+dependent -- kept purely for observability, since neither ever holds a real
+per-deployment bridge lease. `jiji.lease-owned` (`true` only for a genuine
+dynamic bridge lease, `false` for both of the above) tells agent-side
+discovery (`recover_labeled_leases` in `jiji-agent/src/discovery.rs`) which
+is which: without it, discovery would durably record that observability-only
+address as a real claim on every agent restart, a row nothing ever cleans up
+for a `host`-only project (cleanup only runs from the bridge
+`AllocateAddress` path). A container with no `jiji.lease-owned` label at all
+(deployed by a `jiji-cli` build older than this label) still gets the
+previous unconditional recovery attempt, so an in-place agent upgrade never
+regresses recovery for an already-running bridge deployment ahead of its
+next redeploy.
 
 Full detail: `docs/architecture-notes.md#container-namespace-sharing`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,30 @@ upstream's new container exists.
 
 Full detail: `docs/architecture-notes.md#container-namespace-sharing`.
 
+### Host Networking (`network_mode: host`)
+
+A service can share the host's own network namespace via `network_mode:
+"host"` instead of getting a project-bridge address. It still goes through
+the full candidate/active/draining/tombstone catalog lifecycle like a
+bridge-networked service (`deploy_host_mode` in `deploy_transaction.rs`),
+it just never calls the agent's `AllocateAddress` RPC and uses the server's
+`management_address` (its WireGuard mesh address) everywhere a bridge
+deployment would use its leased address: catalog commit, `jiji.lease`
+label. `NetworkedContainerRun::host` renders `--network host` plus
+`--dns*` flags (still needed for `.jiji` resolution; unlike
+`service:<name>` sharing, a host-mode container inherits no one else's
+resolver config) and never `-p`: `ports:` accepts at most one bare
+container-side port as routing/uniqueness metadata only, since `-p`
+combined with `--network host` is a discarded, warning-spamming no-op on
+current Docker/Podman and a hard error on some older Podman releases.
+`proxy:` and `replicas > 1` stay rejected by the same generic non-bridge
+checks `service:<name>` sharing already triggers. `network_mode: none` is
+rejected outright by validation: every service needs a reachable address
+for DNS and health checks, and the one thing `none` is good for (an
+isolated one-off) is already served by `crons:`.
+
+Full detail: `docs/architecture-notes.md#container-namespace-sharing`.
+
 ### Scheduled Cron Execution (`crons:`)
 
 Each service can define `crons:` (name -> `CronConfig`: `schedule`,
@@ -657,12 +681,6 @@ Full detail: `docs/architecture-notes.md#container-engine-provisioning`.
   `secrets:` today changes nothing and produces no warning. `.env` files and
   host-env fallback are implemented; no adapter implementations exist. See
   `docs/todo.md` for the concrete integration plan.
-- `network_mode: "host"` / `"none"` are documented in `crates/jiji-config/
-  src/jiji.yml` but not implemented by any runtime code path:
-  `container_runtime::build_dynamic_run` never reads `network_mode` for
-  either value, so a service configured with them still gets normal bridge
-  networking, silently. Only `"bridge"` (default) and `"service:<name>"`
-  (see "Container Namespace Sharing" above) actually change behavior today.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,10 +229,29 @@ container-side port as routing/uniqueness metadata only, since `-p`
 combined with `--network host` is a discarded, warning-spamming no-op on
 current Docker/Podman and a hard error on some older Podman releases.
 `proxy:` and `replicas > 1` stay rejected by the same generic non-bridge
-checks `service:<name>` sharing already triggers. `network_mode: none` is
-rejected outright by validation: every service needs a reachable address
-for DNS and health checks, and the one thing `none` is good for (an
-isolated one-off) is already served by `crons:`.
+checks `service:<name>` sharing already triggers. A `service:<name>`
+dependent cannot target a `host`-mode upstream either: validation rejects
+it, since joining a host-networked container's namespace would silently
+hand the dependent host networking too, without it ever declaring
+`network_mode: host` itself. `network_mode: none` is rejected outright by
+validation: every service needs a reachable address for DNS and health
+checks, and the one thing `none` is good for (an isolated one-off) is
+already served by `crons:`.
+
+Known gap (not yet fixed): a host-mode container's `jiji.lease` label
+carries `management_address` for observability, the same convention
+`service:<name>` sharing already uses for the upstream's address. Agent-side
+discovery (`recover_labeled_leases` in `jiji-agent/src/discovery.rs`)
+doesn't distinguish this from a genuine per-deployment bridge lease, so it
+tries to claim that label's address as a real lease row keyed by
+`deployment_id`. For `host` mode this produces a permanently-orphaned
+`address_leases` row on every redeploy (cleanup only runs from the bridge
+`AllocateAddress` path, which `host`-mode projects never call) plus a
+recurring "container label conflicts with a durable address lease"
+warning. This bug pattern already existed for `service:<name>` sharing
+before `host` mode was added; fixing it properly needs a way for discovery
+to tell a genuine lease claim apart from an address label kept only for
+observability.
 
 Full detail: `docs/architecture-notes.md#container-namespace-sharing`.
 

--- a/crates/jiji-agent/src/cron_exec.rs
+++ b/crates/jiji-agent/src/cron_exec.rs
@@ -19,7 +19,7 @@ use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use jiji_network::NetworkedContainerRun;
+use jiji_network::{NetworkTarget, NetworkedContainerRun};
 use tracing::warn;
 
 use crate::cron::{CronJobSpec, CronRun, CronRunState};
@@ -124,7 +124,7 @@ fn render_cron_run(
         bridge_interface: String::new(),
         // A cron job is unconditionally rejected at config-validation time for a service using
         // `network_mode: service:<name>`, so a cron container always gets its own address.
-        shared_with_container: None,
+        network_target: NetworkTarget::Bridge,
         extra_args: Vec::new(),
         command: spec.command.clone(),
     };
@@ -682,7 +682,7 @@ mod tests {
             "100.64.0.9".parse().unwrap(),
         )
         .unwrap();
-        assert!(run.shared_with_container.is_none());
+        assert_eq!(run.network_target, NetworkTarget::Bridge);
         let args = run.args();
         let joined = args.join(" ");
         for expected in [

--- a/crates/jiji-agent/src/discovery.rs
+++ b/crates/jiji-agent/src/discovery.rs
@@ -40,12 +40,13 @@ pub async fn discover(engine: Engine, project: &str) -> DiscoveryOutcome {
 
 pub async fn discover_with_binary(binary: &str, engine: Engine, project: &str) -> DiscoveryOutcome {
     let template = format!(
-        "{{{{.ID}}}}|{{{{.Names}}}}|{{{{.Image}}}}|{}|{}|{}|{}|{}|{}|{{{{.State}}}}",
+        "{{{{.ID}}}}|{{{{.Names}}}}|{{{{.Image}}}}|{}|{}|{}|{}|{}|{}|{}|{{{{.State}}}}",
         label_template(engine, "jiji.service"),
         label_template(engine, "jiji.catalog-managed"),
         label_template(engine, "jiji.replica"),
         label_template(engine, "jiji.deployment"),
         label_template(engine, "jiji.lease"),
+        label_template(engine, "jiji.lease-owned"),
         label_template(engine, "jiji.lifecycle"),
     );
     let output = tokio::process::Command::new(binary)
@@ -92,6 +93,7 @@ fn parse_line(line: &str) -> Option<Observation> {
     let replica = fields.next().unwrap_or_default().trim().to_string();
     let deployment = fields.next().unwrap_or_default().trim().to_string();
     let lease = fields.next().unwrap_or_default().trim().to_string();
+    let lease_owned = fields.next().unwrap_or_default().trim().to_string();
     let lifecycle = fields.next().unwrap_or_default().trim().to_string();
     let state = fields.next().unwrap_or_default().trim().to_string();
     let labels_json = serde_json::json!({
@@ -100,6 +102,7 @@ fn parse_line(line: &str) -> Option<Observation> {
         "jiji.replica": replica,
         "jiji.deployment": deployment,
         "jiji.lease": lease,
+        "jiji.lease-owned": lease_owned,
         "jiji.lifecycle": lifecycle,
     })
     .to_string();
@@ -115,6 +118,18 @@ fn parse_line(line: &str) -> Option<Observation> {
 /// Reconstructs durable local leases from positive container-label evidence. A conflicting label
 /// never steals an address: `recover_address_lease` returns false and the allocator continues to
 /// reserve the existing claim until an operator resolves the conflict.
+///
+/// `jiji.lease-owned=false` (set for a `network_mode: service:<name>` dependent or a `host`-mode
+/// container -- see `container_runtime::render_dynamic_labels`) skips recovery entirely: that
+/// container's `jiji.lease` label carries an address kept only for observability (the upstream's
+/// address, or the server's `management_address`), never a real per-deployment bridge claim this
+/// agent's own `AddressAllocator` needs to track. Recovering it anyway would durably record the
+/// server's own management address, or another container's address, as "leased" to a deployment
+/// that never actually leased anything -- a row nothing then ever cleans up, since expiry only
+/// runs from the bridge `AllocateAddress` path. A container without the label at all (deployed by
+/// a jiji-cli build older than this label) still gets the previous unconditional behavior, so an
+/// in-place agent upgrade never regresses recovery for an already-running bridge deployment ahead
+/// of its next redeploy.
 pub fn recover_labeled_leases(
     store: &AgentStore,
     observations: &[Observation],
@@ -131,6 +146,9 @@ pub fn recover_labeled_leases(
                 .filter(|value| !value.is_empty())
         };
         if value("jiji.catalog-managed") != Some("true") {
+            continue;
+        }
+        if value("jiji.lease-owned") == Some("false") {
             continue;
         }
         let (Some(deployment_id), Some(replica_id), Some(address)) = (
@@ -262,7 +280,7 @@ mod tests {
     #[test]
     fn parses_pipe_delimited_ps_output() {
         let observations = parse_lines(
-            "abc123|demo-web-a|nginx:alpine|web|true|replica-1|deploy-1|10.0.0.4|active|running\n\n",
+            "abc123|demo-web-a|nginx:alpine|web|true|replica-1|deploy-1|10.0.0.4|true|active|running\n\n",
         );
         assert_eq!(
             observations,
@@ -276,6 +294,7 @@ mod tests {
                     "jiji.replica": "replica-1",
                     "jiji.deployment": "deploy-1",
                     "jiji.lease": "10.0.0.4",
+                    "jiji.lease-owned": "true",
                     "jiji.lifecycle": "active",
                 })
                 .to_string(),
@@ -295,7 +314,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let engine_path = write_fake_engine(
             dir.path(),
-            "echo 'abc123|demo-web-a|nginx:alpine|web|true|replica-1|deploy-1|10.0.0.4|active|running'",
+            "echo 'abc123|demo-web-a|nginx:alpine|web|true|replica-1|deploy-1|10.0.0.4|true|active|running'",
         );
         let outcome =
             discover_with_binary(engine_path.to_str().unwrap(), Engine::Docker, "demo").await;
@@ -311,6 +330,7 @@ mod tests {
                     "jiji.replica": "replica-1",
                     "jiji.deployment": "deploy-1",
                     "jiji.lease": "10.0.0.4",
+                    "jiji.lease-owned": "true",
                     "jiji.lifecycle": "active",
                 })
                 .to_string(),
@@ -335,17 +355,49 @@ mod tests {
             .claim_address_lease("deploy-1", "replica-1", "10.0.0.4".parse().unwrap())
             .unwrap();
         store.quarantine_address_lease("deploy-1", 999).unwrap();
-        let observations =
-            parse_lines("abc|demo-web|nginx|web|true|replica-1|deploy-1|10.0.0.4|active|running");
+        let observations = parse_lines(
+            "abc|demo-web|nginx|web|true|replica-1|deploy-1|10.0.0.4|true|active|running",
+        );
         assert_eq!(recover_labeled_leases(&store, &observations).unwrap(), 1);
         let lease = store.address_lease("deploy-1").unwrap().unwrap();
         assert_eq!(lease.state, "active");
         assert_eq!(lease.quarantine_until, None);
 
-        let conflicting =
-            parse_lines("def|demo-web-2|nginx|web|true|replica-2|deploy-2|10.0.0.4|active|running");
+        let conflicting = parse_lines(
+            "def|demo-web-2|nginx|web|true|replica-2|deploy-2|10.0.0.4|true|active|running",
+        );
         assert_eq!(recover_labeled_leases(&store, &conflicting).unwrap(), 0);
         assert!(store.address_lease("deploy-2").unwrap().is_none());
+    }
+
+    /// A `network_mode: service:<name>` dependent or a `host`-mode container labels `jiji.lease`
+    /// with an address it never actually leased (the upstream's address, or the server's own
+    /// `management_address`) purely for observability, and marks that with
+    /// `jiji.lease-owned=false`. Recovery must skip it entirely, not durably claim that address for
+    /// a `deployment_id` that never leased anything.
+    #[test]
+    fn lease_owned_false_is_never_recovered_as_a_real_claim() {
+        let dir = tempdir().unwrap();
+        let store = AgentStore::open(&dir.path().join("agent.sqlite3")).unwrap();
+        let observations = parse_lines(
+            "abc|demo-web-host|nginx|web|true|replica-1|deploy-1|198.18.0.1|false|active|running",
+        );
+        assert_eq!(recover_labeled_leases(&store, &observations).unwrap(), 0);
+        assert!(store.address_lease("deploy-1").unwrap().is_none());
+    }
+
+    /// A container deployed before this label existed has an empty `jiji.lease-owned` field (no
+    /// such Docker/Podman label to fill the template slot), which must fall back to the previous
+    /// unconditional recovery attempt -- never a silent regression on an in-place agent upgrade.
+    #[test]
+    fn legacy_container_without_the_lease_owned_label_still_recovers() {
+        let dir = tempdir().unwrap();
+        let store = AgentStore::open(&dir.path().join("agent.sqlite3")).unwrap();
+        let observations =
+            parse_lines("abc|demo-web|nginx|web|true|replica-1|deploy-1|10.0.0.4||active|running");
+        assert_eq!(recover_labeled_leases(&store, &observations).unwrap(), 1);
+        let lease = store.address_lease("deploy-1").unwrap().unwrap();
+        assert_eq!(lease.state, "active");
     }
 
     #[tokio::test]

--- a/crates/jiji-cli/src/container_ops.rs
+++ b/crates/jiji-cli/src/container_ops.rs
@@ -1,5 +1,5 @@
 use jiji_config::ContainerEngine;
-use jiji_network::NetworkedContainerRun;
+use jiji_network::{NetworkTarget, NetworkedContainerRun};
 use jiji_ssh::{CommandResult, SshSession, StreamChunk};
 use std::time::Duration;
 
@@ -173,8 +173,8 @@ pub async fn create_and_start(
     ensure_success(session, &command, &result)?;
     // A `network_mode: service:<other>` dependent has no bridge attachment of its own to
     // reconcile -- it inherits the upstream's, already handled by the upstream's own
-    // create_and_start call.
-    if run.shared_with_container.is_some() {
+    // create_and_start call. A `network_mode: host` container has no bridge attachment either.
+    if !matches!(run.network_target, NetworkTarget::Bridge) {
         return Ok(());
     }
     crate::commands::network::bridge::reconcile_podman_dns_address(

--- a/crates/jiji-cli/src/container_runtime.rs
+++ b/crates/jiji-cli/src/container_runtime.rs
@@ -60,6 +60,16 @@ pub fn render_labels(project: &str, service: &str, server: &str) -> Vec<String> 
     ]
 }
 
+/// `owns_lease` distinguishes a genuine per-deployment bridge address claim (`build_dynamic_run`)
+/// from `lease_address` being kept on the label purely for observability -- the upstream's address
+/// for a `service:<name>` dependent, or the server's `management_address` for `host` mode. Agent
+/// startup (`discovery::recover_labeled_leases`) reads `jiji.lease-owned` to decide whether this
+/// label is real lease evidence to reconstruct into the durable `address_leases` table, or an
+/// address this container never actually leased. `false` is rendered explicitly (rather than
+/// omitting the label) so a legacy container without it -- deployed before this label existed --
+/// still gets the old, back-compat-safe "attempt recovery" behavior, never a silent regression for
+/// an in-place agent upgrade ahead of that container's next redeploy.
+#[allow(clippy::too_many_arguments)]
 pub fn render_dynamic_labels(
     project: &str,
     service: &str,
@@ -68,6 +78,7 @@ pub fn render_dynamic_labels(
     deployment_id: &str,
     lease_address: Ipv4Addr,
     lifecycle: &str,
+    owns_lease: bool,
 ) -> Vec<String> {
     let mut labels = render_labels(project, service, server);
     for value in [
@@ -75,6 +86,7 @@ pub fn render_dynamic_labels(
         format!("jiji.replica={replica_id}"),
         format!("jiji.deployment={deployment_id}"),
         format!("jiji.lease={lease_address}"),
+        format!("jiji.lease-owned={owns_lease}"),
         format!("jiji.lifecycle={lifecycle}"),
     ] {
         labels.push("--label".to_string());
@@ -113,6 +125,7 @@ pub fn build_dynamic_run(
         deployment_id,
         address,
         "candidate",
+        true,
     ));
     run.extra_args.extend(render_ports(&service.ports));
     run.extra_args.extend(mount_args.iter().cloned());
@@ -167,6 +180,7 @@ pub fn build_shared_run(
         deployment_id,
         upstream_address,
         "candidate",
+        false,
     ));
     run.extra_args.extend(mount_args.iter().cloned());
     run.extra_args.push("--env-file".to_string());
@@ -214,6 +228,7 @@ pub fn build_host_run(
         deployment_id,
         address,
         "candidate",
+        false,
     ));
     run.extra_args.extend(mount_args.iter().cloned());
     run.extra_args.push("--env-file".to_string());

--- a/crates/jiji-cli/src/container_runtime.rs
+++ b/crates/jiji-cli/src/container_runtime.rs
@@ -176,6 +176,53 @@ pub fn build_shared_run(
     run
 }
 
+/// Builds the run for a `network_mode: host` service: shares the host's own network namespace
+/// instead of a leased bridge address. `address` is the server's `management_address`, kept only
+/// for the `jiji.lease` label and catalog/observability use -- it is never rendered into `--ip`,
+/// since a host-networked container has no address of its own (see `NetworkedContainerRun::host`).
+/// Ports are deliberately never rendered here: `-p` combined with `--network host` is at best a
+/// discarded, warning-spamming no-op and at worst a hard error on some engine versions (see
+/// `docs/architecture-notes.md#container-namespace-sharing`); the app must already bind whatever
+/// port it wants directly on the host.
+#[allow(clippy::too_many_arguments)]
+pub fn build_host_run(
+    engine: ContainerEngine,
+    project: &str,
+    service_name: &str,
+    server_name: &str,
+    replica_id: &str,
+    deployment_id: &str,
+    image: &str,
+    address: Ipv4Addr,
+    server: &ServerPlan,
+    service: &Service,
+    mount_args: &[String],
+    env_file_path: &str,
+) -> NetworkedContainerRun {
+    let name = dynamic_container_name(project, service_name, deployment_id);
+    let mut run = NetworkedContainerRun::host(engine, name, image, address, server);
+    run.extra_args = vec![
+        "--detach".to_string(),
+        "--restart".to_string(),
+        service.restart.unwrap_or_default().to_string(),
+    ];
+    run.extra_args.extend(render_dynamic_labels(
+        project,
+        service_name,
+        server_name,
+        replica_id,
+        deployment_id,
+        address,
+        "candidate",
+    ));
+    run.extra_args.extend(mount_args.iter().cloned());
+    run.extra_args.push("--env-file".to_string());
+    run.extra_args.push(env_file_path.to_string());
+    run.extra_args.extend(render_resource_options(service));
+    run.command = render_command(&service.command);
+    run
+}
+
 pub fn dynamic_container_name(project: &str, service: &str, deployment_id: &str) -> String {
     let suffix = deployment_id.get(..12).unwrap_or(deployment_id);
     format!("{project}-{service}-{suffix}")
@@ -417,5 +464,36 @@ cap_add: ["SYS_ADMIN"]
             vec!["./run.sh".to_string(), "--flag".to_string()]
         );
         assert!(render_command(&None).is_empty());
+    }
+
+    #[test]
+    fn build_host_run_uses_network_host_omits_ports_and_labels_management_address() {
+        use jiji_network::NetworkPlanner;
+
+        let config: jiji_config::Config = serde_yaml::from_str(
+            "project: demo\nbuilder: { engine: docker }\nservers:\n  app: { host: 203.0.113.10 }\nservices:\n  web: { image: nginx, servers: [app], network_mode: host, ports: [\"8080\"] }\n",
+        )
+        .unwrap();
+        let plan = NetworkPlanner::new().plan(&config).unwrap();
+        let server = &plan.servers["app"];
+        let service = &config.services["web"];
+        let run = build_host_run(
+            ContainerEngine::Docker,
+            "demo",
+            "web",
+            "app",
+            "replica-1",
+            "deadbeefdeadbeef",
+            "nginx:latest",
+            server.management_address,
+            server,
+            service,
+            &[],
+            "/tmp/env",
+        );
+        let command = run.shell_command();
+        assert!(command.contains("--network host"));
+        assert!(!command.contains("-p 8080"));
+        assert!(command.contains(&format!("jiji.lease={}", server.management_address)));
     }
 }

--- a/crates/jiji-cli/src/deploy_transaction.rs
+++ b/crates/jiji-cli/src/deploy_transaction.rs
@@ -39,9 +39,13 @@ pub enum EndpointOutcome {
 }
 
 pub async fn deploy_endpoint(ctx: &EndpointDeploymentContext<'_>) -> EndpointOutcome {
-    let result = match ctx.service.network_mode_dependency() {
-        Some(upstream_service_name) => deploy_shared_endpoint(ctx, upstream_service_name).await,
-        None => deploy_dynamic_endpoint(ctx).await,
+    let result = if ctx.service.network_mode == "host" {
+        deploy_host_mode(ctx).await
+    } else {
+        match ctx.service.network_mode_dependency() {
+            Some(upstream_service_name) => deploy_shared_endpoint(ctx, upstream_service_name).await,
+            None => deploy_dynamic_endpoint(ctx).await,
+        }
     };
     match result {
         Ok((deployment_id, _address)) => EndpointOutcome::Deployed { deployment_id },
@@ -505,6 +509,208 @@ async fn deploy_dynamic_endpoint(
             return Ok((deployment_id, address));
         }
         finish_orphaned_static_image_cleanup(ctx, orphaned_image).await;
+        let _ = crate::agent_client::call(
+            ctx.session,
+            project,
+            Some(format!("release:{}", previous.deployment_id)),
+            RequestBody::ReleaseAddress {
+                deployment_id: previous.deployment_id.clone(),
+                timestamp,
+            },
+        )
+        .await?;
+        commit_catalog(
+            ctx,
+            &previous.replica_id,
+            &previous.deployment_id,
+            previous.address,
+            previous.ports,
+            DeploymentState::Tombstoned,
+            HealthState::Unknown,
+        )
+        .await?;
+    }
+    sweep_stuck_draining_records(ctx, ctx.service_name, Some(ctx.service)).await;
+    Ok((deployment_id, address))
+}
+
+/// Deploys a `network_mode: host` service: a container that shares the host's own network
+/// namespace instead of leasing a bridge address. Closer in shape to `deploy_dynamic_endpoint`
+/// than to `deploy_shared_endpoint`: it still creates a genuinely new container with the full
+/// candidate/active/draining/tombstone catalog lifecycle and a container-readiness health check,
+/// it just never calls `AllocateAddress` and uses `ctx.server.management_address` everywhere the
+/// dynamic path uses the leased address. `proxy:` is rejected by validation for any non-bridge
+/// mode, so there is never a route to activate here (mirrors `deploy_shared_endpoint`'s "no
+/// healthcheck config exists" fallback for the same reason).
+async fn deploy_host_mode(
+    ctx: &EndpointDeploymentContext<'_>,
+) -> anyhow::Result<(String, std::net::Ipv4Addr)> {
+    use sha2::{Digest, Sha256};
+
+    let project = &ctx.plan.project;
+    let replica_id = ctx.replica_id.to_string();
+    let nonce = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let deployment_id = Sha256::digest(
+        format!("{project}\0{replica_id}\0{nonce}\0{}", std::process::id()).as_bytes(),
+    )
+    .iter()
+    .map(|byte| format!("{byte:02x}"))
+    .collect::<String>();
+    let candidate_name =
+        container_runtime::dynamic_container_name(project, ctx.service_name, &deployment_id);
+    let address = ctx.server.management_address;
+    let committed_ports: Vec<u16> = ctx
+        .service
+        .ports
+        .first()
+        .and_then(|port| port.parse::<u16>().ok())
+        .into_iter()
+        .collect();
+
+    let catalog = crate::agent_client::catalog(ctx.session, project).await?;
+    let previous = catalog
+        .iter()
+        .find(|record| {
+            record.replica_id == replica_id
+                && record.state == DeploymentState::Active
+                && record.health == HealthState::Healthy
+        })
+        .cloned();
+
+    if ctx.service.stop_first {
+        if let Some(previous) = &previous {
+            let previous_name = container_runtime::dynamic_container_name(
+                project,
+                ctx.service_name,
+                &previous.deployment_id,
+            );
+            container_ops::stop(ctx.session, ctx.engine, &previous_name).await?;
+        }
+    }
+
+    container_ops::ensure_image(ctx.session, ctx.engine, ctx.image).await?;
+    let mount_args = mounts::prepare_mounts(
+        ctx.session,
+        ctx.service,
+        ctx.service_name,
+        project,
+        ctx.project_root,
+        ctx.max_dir_upload_bytes,
+    )
+    .await?;
+    let env_file_path = crate::env_resolution::stage_env_file(
+        ctx.session,
+        project,
+        ctx.service_name,
+        &ctx.server.name,
+        ctx.resolved_env,
+    )
+    .await?;
+    let run = container_runtime::build_host_run(
+        ctx.engine,
+        project,
+        ctx.service_name,
+        &ctx.server.name,
+        &replica_id,
+        &deployment_id,
+        ctx.image,
+        address,
+        ctx.server,
+        ctx.service,
+        &mount_args,
+        &env_file_path,
+    );
+
+    commit_catalog(
+        ctx,
+        &replica_id,
+        &deployment_id,
+        address,
+        committed_ports.clone(),
+        DeploymentState::Candidate,
+        HealthState::Unknown,
+    )
+    .await?;
+
+    report_progress(ctx, "starting container");
+    if let Err(error) = container_ops::create_and_start(ctx.session, &run).await {
+        release_candidate(ctx, &replica_id, &deployment_id, address, &candidate_name).await;
+        restore_stop_first(ctx, previous.as_ref()).await;
+        return Err(error);
+    }
+
+    let health_plan =
+        health_check::plan_for_candidate(ctx.engine, &candidate_name, address, 0, None);
+    report_progress(
+        ctx,
+        &health_check_progress_detail(health_plan.deploy_timeout),
+    );
+    if let Err(error) = health_check::wait_until_healthy(
+        ctx.session,
+        ctx.engine,
+        &candidate_name,
+        &health_plan,
+        |line| health_check_line_progress(ctx, line),
+    )
+    .await
+    {
+        release_candidate(ctx, &replica_id, &deployment_id, address, &candidate_name).await;
+        restore_stop_first(ctx, previous.as_ref()).await;
+        let message = redact_secrets(&error.to_string(), ctx.resolved_env);
+        return Err(anyhow::anyhow!(message));
+    }
+
+    commit_catalog(
+        ctx,
+        &replica_id,
+        &deployment_id,
+        address,
+        committed_ports.clone(),
+        DeploymentState::Active,
+        HealthState::Healthy,
+    )
+    .await?;
+
+    if let Some(previous) = previous {
+        commit_catalog(
+            ctx,
+            &previous.replica_id,
+            &previous.deployment_id,
+            previous.address,
+            previous.ports.clone(),
+            DeploymentState::Draining,
+            HealthState::Unknown,
+        )
+        .await?;
+        let old_name = container_runtime::dynamic_container_name(
+            project,
+            ctx.service_name,
+            &previous.deployment_id,
+        );
+        let orphaned_image =
+            capture_orphaned_static_image(ctx, ctx.service_name, Some(ctx.service), &old_name)
+                .await;
+        let _ = container_ops::stop(ctx.session, ctx.engine, &old_name).await;
+        if let Err(error) =
+            container_ops::remove_if_present(ctx.session, ctx.engine, &old_name).await
+        {
+            if !is_dependent_container_error(&error) {
+                return Err(error);
+            }
+            tracing::warn!(
+                container = %old_name,
+                service = ctx.service_name,
+                "previous container still has a network_mode:service dependent attached; \
+                 deferring its removal until that dependent redeploys"
+            );
+            sweep_stuck_draining_records(ctx, ctx.service_name, Some(ctx.service)).await;
+            return Ok((deployment_id, address));
+        }
+        finish_orphaned_static_image_cleanup(ctx, orphaned_image).await;
+        // No lease was ever allocated for a host-mode container, but the release call stays
+        // unconditional (matching `deploy_shared_endpoint`'s precedent): the agent's release
+        // handler already no-ops correctly when nothing was ever leased for this `deployment_id`.
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
         let _ = crate::agent_client::call(
             ctx.session,
             project,

--- a/crates/jiji-cli/tests/network_mode_host_test.rs
+++ b/crates/jiji-cli/tests/network_mode_host_test.rs
@@ -1,0 +1,449 @@
+//! Integration tests for `network_mode: "host"`, mirroring `network_mode_service_test.rs`'s
+//! in-process mock-SSH pattern. Unlike that harness, this one also captures each exec channel's
+//! stdin (the JSON `jiji-agent request` body) so the catalog-commit address can be asserted on
+//! directly, not just inferred from the rendered `docker run` command.
+
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use jiji_config::Config;
+use jiji_network::NetworkPlanner;
+use rand::rng;
+use russh::keys::ssh_key::LineEnding;
+use russh::keys::{Algorithm, PrivateKey, PublicKey};
+use russh::server::{self, Auth, ChannelOpenHandle, Server as _, Session};
+use russh::{Channel, ChannelId};
+use tokio::net::TcpListener;
+
+#[derive(Clone, Default)]
+struct CannedResponse {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+fn success(stdout: &str) -> CannedResponse {
+    CannedResponse {
+        success: true,
+        stdout: stdout.to_string(),
+        stderr: String::new(),
+    }
+}
+
+fn default_response(command: &str) -> CannedResponse {
+    let body = if command.contains("# jiji-request:catalog-list") {
+        r#"{"Ok":{"type":"catalog_list","records":[]}}"#
+    } else if command.contains("# jiji-request:desired-commit") {
+        r#"{"Ok":{"type":"desired_state","record":{"project_id":"demo","recovery_epoch":1,"protocol_version":1,"schema_version":1,"service":"app","replica_override":1,"assignments":[{"replica_id":"app-test","ordinal":0,"owner_node_id":"app"}],"revision":1,"author_node_id":"app","author_epoch":1}}}"#
+    } else if command.contains("# jiji-request:desired-read") {
+        r#"{"Ok":{"type":"desired_state","record":null}}"#
+    } else if command.contains("# jiji-request:catalog-commit") {
+        r#"{"Ok":{"type":"catalog_committed","record":{"project_id":"demo","recovery_epoch":1,"protocol_version":1,"schema_version":2,"service":"app","replica_id":"app-test","owner_node_id":"app","owner_epoch":1,"revision":1,"deployment_id":"aabbccddeeff001122","address":"100.64.0.1","ports":[8080],"image":"docker.io/library/nginx:latest","state":"active","health":"healthy"}}}"#
+    } else if command.contains("# jiji-request:release-address") {
+        r#"{"Ok":{"type":"address_released","released":true}}"#
+    } else if command.contains("# jiji-request:cron-spec-list") {
+        r#"{"Ok":{"type":"cron_specs","specs":[]}}"#
+    } else if command.contains("# jiji-request:image-retention-remove") {
+        r#"{"Ok":{"type":"image_retention_removed","removed":true}}"#
+    } else if command.contains("# jiji-request:health") {
+        return success(&format!(
+            r#"{{"Ok":{{"type":"health","schema_version":1,"observation_count":0,"version":"{}"}}}}"#,
+            env!("CARGO_PKG_VERSION")
+        ));
+    } else {
+        ""
+    };
+    success(body)
+}
+
+#[derive(Clone)]
+struct TestServer {
+    authorized_key: PublicKey,
+    responses: Arc<HashMap<String, CannedResponse>>,
+    pending: Arc<Mutex<HashMap<ChannelId, String>>>,
+    stdin: Arc<Mutex<HashMap<ChannelId, Vec<u8>>>>,
+    received: Arc<Mutex<Vec<String>>>,
+    received_payloads: Arc<Mutex<Vec<(String, String)>>>,
+}
+
+impl server::Server for TestServer {
+    type Handler = Self;
+
+    fn new_client(&mut self, _peer_addr: Option<SocketAddr>) -> Self {
+        self.clone()
+    }
+}
+
+impl server::Handler for TestServer {
+    type Error = russh::Error;
+
+    async fn auth_publickey(&mut self, _user: &str, key: &PublicKey) -> Result<Auth, Self::Error> {
+        Ok(if *key == self.authorized_key {
+            Auth::Accept
+        } else {
+            Auth::reject()
+        })
+    }
+
+    async fn channel_open_session(
+        &mut self,
+        _channel: Channel<server::Msg>,
+        reply: ChannelOpenHandle,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        reply.accept().await;
+        Ok(())
+    }
+
+    async fn exec_request(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        self.pending
+            .lock()
+            .expect("pending mutex poisoned")
+            .insert(channel, String::from_utf8_lossy(data).into_owned());
+        session.channel_success(channel)?;
+        Ok(())
+    }
+
+    async fn data(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        self.stdin
+            .lock()
+            .expect("stdin mutex poisoned")
+            .entry(channel)
+            .or_default()
+            .extend_from_slice(data);
+        Ok(())
+    }
+
+    async fn channel_eof(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let command = self
+            .pending
+            .lock()
+            .expect("pending mutex poisoned")
+            .remove(&channel)
+            .unwrap_or_default();
+        self.received
+            .lock()
+            .expect("received mutex poisoned")
+            .push(command.clone());
+        let stdin_bytes = self
+            .stdin
+            .lock()
+            .expect("stdin mutex poisoned")
+            .remove(&channel)
+            .unwrap_or_default();
+        self.received_payloads
+            .lock()
+            .expect("received_payloads mutex poisoned")
+            .push((
+                command.clone(),
+                String::from_utf8_lossy(&stdin_bytes).into_owned(),
+            ));
+
+        let occurrence = self
+            .received
+            .lock()
+            .expect("received mutex poisoned")
+            .iter()
+            .filter(|received| *received == &command)
+            .count();
+        let response = self
+            .responses
+            .get(&format!("{command}#{occurrence}"))
+            .or_else(|| self.responses.get(&command))
+            .cloned()
+            .unwrap_or_else(|| default_response(&command));
+
+        if !response.stdout.is_empty() {
+            session.data(channel, response.stdout)?;
+        }
+        if !response.stderr.is_empty() {
+            session.extended_data(channel, 1, response.stderr)?;
+        }
+        session.exit_status_request(channel, if response.success { 0 } else { 1 })?;
+        session.eof(channel)?;
+        session.close(channel)?;
+        Ok(())
+    }
+}
+
+struct Harness {
+    addr: SocketAddr,
+    received: Arc<Mutex<Vec<String>>>,
+    received_payloads: Arc<Mutex<Vec<(String, String)>>>,
+}
+
+async fn spawn_test_server(
+    authorized_key: PublicKey,
+    responses: HashMap<String, CannedResponse>,
+) -> Harness {
+    let config = Arc::new(server::Config {
+        auth_rejection_time: Duration::from_millis(50),
+        keys: vec![PrivateKey::random(&mut rng(), Algorithm::Ed25519).expect("generate host key")],
+        ..Default::default()
+    });
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("read listener addr");
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let received_payloads = Arc::new(Mutex::new(Vec::new()));
+    let mut test_server = TestServer {
+        authorized_key,
+        responses: Arc::new(responses),
+        pending: Arc::new(Mutex::new(HashMap::new())),
+        stdin: Arc::new(Mutex::new(HashMap::new())),
+        received: received.clone(),
+        received_payloads: received_payloads.clone(),
+    };
+
+    tokio::spawn(async move {
+        let _ = test_server.run_on_socket(config, &listener).await;
+        drop(listener);
+    });
+
+    Harness {
+        addr,
+        received,
+        received_payloads,
+    }
+}
+
+/// A single `network_mode: host` service ("app") on a single server ("app"), listening on 8080.
+fn config_yaml(addr: SocketAddr, key_path: &std::path::Path) -> String {
+    format!(
+        r#"
+project: demo
+builder: {{ engine: docker }}
+servers:
+  app:
+    host: {ip}
+    port: {port}
+    keys:
+      - {key_path}
+services:
+  app:
+    image: nginx:latest
+    servers: [app]
+    network_mode: host
+    ports: ["8080"]
+ssh:
+  user: tester
+  keys_only: true
+"#,
+        ip = addr.ip(),
+        port = addr.port(),
+        key_path = key_path.display(),
+    )
+}
+
+fn write_config(
+    dir: &std::path::Path,
+    addr: SocketAddr,
+    key_path: &std::path::Path,
+) -> std::path::PathBuf {
+    let config_path = dir.join("deploy.yml");
+    std::fs::write(&config_path, config_yaml(addr, key_path)).expect("write test deploy.yml");
+    config_path
+}
+
+fn plan_generation(addr: SocketAddr) -> String {
+    plan(addr).mesh_generation
+}
+
+fn plan(addr: SocketAddr) -> jiji_network::NetworkPlan {
+    let yaml = config_yaml(addr, std::path::Path::new("/dev/null"));
+    let config: Config = serde_yaml::from_str(&yaml).expect("parse test config");
+    NetworkPlanner::new()
+        .plan(&config)
+        .expect("build test plan")
+}
+
+fn management_address(addr: SocketAddr) -> Ipv4Addr {
+    plan(addr).servers["app"].management_address
+}
+
+fn run_jiji_deploy(config_path: &std::path::Path, extra_args: &[&str]) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_jiji"));
+    command
+        .arg("deploy")
+        .arg("-c")
+        .arg(config_path)
+        .arg("--yes");
+    for arg in extra_args {
+        command.arg(arg);
+    }
+    command.output().expect("run jiji deploy")
+}
+
+fn run_jiji_service_remove(
+    config_path: &std::path::Path,
+    extra_args: &[&str],
+) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_jiji"));
+    command
+        .arg("service")
+        .arg("remove")
+        .arg("-c")
+        .arg(config_path)
+        .arg("-y");
+    for arg in extra_args {
+        command.arg(arg);
+    }
+    command.output().expect("run jiji service remove")
+}
+
+fn setup_test_dir() -> (tempfile::TempDir, std::path::PathBuf, PrivateKey) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let client_key =
+        PrivateKey::random(&mut rng(), Algorithm::Ed25519).expect("generate client key");
+    let key_path = dir.path().join("id_ed25519");
+    std::fs::write(
+        &key_path,
+        client_key
+            .to_openssh(LineEnding::LF)
+            .expect("encode key as openssh")
+            .as_bytes(),
+    )
+    .expect("write key file");
+    (dir, key_path, client_key)
+}
+
+fn slug() -> String {
+    jiji_network::systemd_unit_slug("demo")
+}
+
+fn network_dir() -> String {
+    format!("/etc/jiji/network/{}", slug())
+}
+
+fn generation_path() -> String {
+    format!("cat {}/mesh-generation 2>/dev/null || true", network_dir())
+}
+
+fn service_runtime_generation_path() -> String {
+    format!(
+        "cat {}/service-runtime-generation 2>/dev/null || true",
+        network_dir()
+    )
+}
+
+fn image_inspect_command(image: &str) -> String {
+    format!("docker image inspect {image} >/dev/null 2>&1")
+}
+
+fn base_responses(generation: &str) -> HashMap<String, CannedResponse> {
+    let mut responses = HashMap::new();
+    responses.insert(generation_path(), success(&format!("{generation}\n")));
+    responses.insert(
+        service_runtime_generation_path(),
+        success(&format!("{generation}\n")),
+    );
+    responses.insert(
+        image_inspect_command("docker.io/library/nginx:latest"),
+        success(""),
+    );
+    responses
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn host_mode_deploy_renders_network_host_without_ports_or_lease() {
+    let (dir, key_path, client_key) = setup_test_dir();
+    let generation = plan_generation(SocketAddr::from(([127, 0, 0, 1], 0)));
+    let responses = base_responses(&generation);
+
+    let harness = spawn_test_server(client_key.public_key().clone(), responses).await;
+    let config_path = write_config(dir.path(), harness.addr, &key_path);
+    let expected_address = management_address(harness.addr);
+
+    let output = run_jiji_deploy(&config_path, &["-S", "app"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let received = harness.received.lock().unwrap().clone();
+    assert!(
+        received
+            .iter()
+            .any(|c| c.contains("docker run --name demo-app-")
+                && c.contains("--network host")
+                && !c.contains("--ip")
+                && !c.contains("-p 8080")),
+        "app should run with --network host, no --ip, no -p: {received:?}"
+    );
+    assert!(
+        !received
+            .iter()
+            .any(|c| c.contains("# jiji-request:allocate-address")),
+        "a host-mode deploy must never lease an address: {received:?}"
+    );
+
+    let payloads = harness.received_payloads.lock().unwrap().clone();
+    let active_commit = payloads.iter().find(|(command, stdin)| {
+        command.contains("# jiji-request:catalog-commit") && stdin.contains("\"state\":\"active\"")
+    });
+    let (_, stdin) = active_commit.expect("expected an Active catalog-commit payload");
+    assert!(
+        stdin.contains(&format!("\"address\":\"{expected_address}\"")),
+        "Active catalog record should carry the server's management_address {expected_address}: {stdin}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn host_mode_remove_issues_its_normal_no_op_release_call() {
+    let (dir, key_path, client_key) = setup_test_dir();
+    let generation = plan_generation(SocketAddr::from(([127, 0, 0, 1], 0)));
+    let mut responses = base_responses(&generation);
+    let expected_address = management_address(SocketAddr::from(([127, 0, 0, 1], 0)));
+    responses.insert(
+        "docker inspect demo-app-aabbccddeeff --format '{{.State.Status}}'".to_string(),
+        success("running\n"),
+    );
+    responses.insert(
+        format!(
+            "/etc/jiji/agent/{}/bin/jiji-agent request --socket /etc/jiji/agent/{}/agent.sock # jiji-request:catalog-list",
+            slug(),
+            slug()
+        ),
+        success(&format!(
+            r#"{{"Ok":{{"type":"catalog_list","records":[{{"project_id":"demo","recovery_epoch":1,"protocol_version":1,"schema_version":2,"service":"app","replica_id":"app-test","owner_node_id":"app","owner_epoch":1,"revision":1,"deployment_id":"aabbccddeeff001122","address":"{expected_address}","ports":[8080],"image":"docker.io/library/nginx:latest","state":"active","health":"healthy"}}]}}}}"#
+        )),
+    );
+
+    let harness = spawn_test_server(client_key.public_key().clone(), responses).await;
+    let config_path = write_config(dir.path(), harness.addr, &key_path);
+
+    let output = run_jiji_service_remove(&config_path, &["-S", "app"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let received = harness.received.lock().unwrap().clone();
+    assert!(received.contains(&"docker stop demo-app-aabbccddeeff".to_string()));
+    assert!(received.contains(&"docker rm -f demo-app-aabbccddeeff".to_string()));
+    assert!(received
+        .iter()
+        .any(|command| command.contains("# jiji-request:catalog-commit")));
+    assert!(
+        received
+            .iter()
+            .any(|command| command.contains("# jiji-request:release-address")),
+        "remove must still issue its normal (no-op) release call even though host mode never leased an address: {received:?}"
+    );
+}

--- a/crates/jiji-config/src/jiji.yml
+++ b/crates/jiji-config/src/jiji.yml
@@ -942,10 +942,21 @@ services:
 #       once the upstream's old container is torn down). This is not itself zero-downtime
 #       with respect to upstream churn: there is a brief gap between the upstream's cutover
 #       completing and each dependent's own redeploy completing.
-#   - "host" and "none" are accepted by the schema but are not currently implemented by any
-#     runtime code path -- setting either one is silently ignored and the service still gets
-#     normal bridge networking. Only "bridge" and "service:<name>" actually change behavior
-#     today. Docker's native "container:<id>" syntax is explicitly rejected by validation.
+#     - "host" - Shares the host's own network namespace instead of getting a project-bridge
+#       address. `ports:` accepts at most one entry, a bare container-side port number only
+#       (e.g. "8080"), never a host:container mapping or a "/udp" suffix: it is metadata only
+#       (what the service listens on, for the per-server uniqueness check below), never
+#       rendered as `-p` -- the app must already bind the port it wants directly on the host.
+#       Two `host`-mode services whose `servers` overlap cannot declare the same port; this
+#       check is project-scoped only, so a different project's `host`-mode service on a shared
+#       machine can still collide, surfacing as a failed container start instead. `proxy:` and
+#       `replicas` > 1 stay rejected, the same as any other non-bridge mode. Host networking
+#       removes jiji's mesh isolation for that container: it can reach, and be reached by,
+#       anything the host's own network can, bypassing the project bridge entirely.
+#     - "none" - Not supported. Every service needs a reachable address for DNS and health
+#       checks; rejected by validation with a pointer to `service:<name>` (explicit sharing) or
+#       `crons:` (isolated one-off/scheduled work) as the supported alternatives.
+#   - Docker's native "container:<id>" syntax is explicitly rejected by validation.
 #
 # devices: Device mappings for hardware access
 #   - Type: array of strings

--- a/crates/jiji-config/src/validation.rs
+++ b/crates/jiji-config/src/validation.rs
@@ -199,6 +199,15 @@ pub fn validate_config(config: &Config) -> ValidationResult {
                         code: "NETWORK_MODE_SERVICE_CHAIN_UNSUPPORTED",
                     });
                 }
+                if upstream.network_mode == "host" {
+                    errors.push(ValidationError {
+                        path: format!("services.{name}.network_mode"),
+                        message: format!(
+                            "Service '{name}' cannot depend on '{upstream_name}', which uses network_mode: host; a dependent can only share a network_mode: bridge upstream's namespace"
+                        ),
+                        code: "NETWORK_MODE_SERVICE_HOST_UPSTREAM_UNSUPPORTED",
+                    });
+                }
                 if !service
                     .servers
                     .iter()
@@ -621,6 +630,16 @@ fn validate_host_network_ports(config: &Config, errors: &mut Vec<ValidationError
             });
             continue;
         };
+        if port == 0 {
+            errors.push(ValidationError {
+                path: format!("services.{name}.ports"),
+                message: format!(
+                    "Service '{name}' uses network_mode: host; 'ports' entry '0' is not a valid port."
+                ),
+                code: "HOST_NETWORK_INVALID_PORT",
+            });
+            continue;
+        }
         for (existing_port, existing_service, existing_servers) in &seen_ports {
             if *existing_port == port
                 && service

--- a/crates/jiji-config/src/validation.rs
+++ b/crates/jiji-config/src/validation.rs
@@ -155,6 +155,15 @@ pub fn validate_config(config: &Config) -> ValidationResult {
                 code: "UNSUPPORTED_NETWORK_MODE",
             });
         }
+        if service.network_mode == "none" {
+            errors.push(ValidationError {
+                path: format!("services.{name}.network_mode"),
+                message: format!(
+                    "Service '{name}' uses network_mode: none, which is not supported: every service needs a reachable address for DNS and health checks. Use 'network_mode: service:<name>' to explicitly share another service's namespace, or 'crons:' for isolated one-off/scheduled work."
+                ),
+                code: "NETWORK_MODE_NONE_UNSUPPORTED",
+            });
+        }
         if service.replicas > 1 && service.network_mode != "bridge" {
             errors.push(ValidationError {
                 path: format!("services.{name}.network_mode"),
@@ -266,6 +275,7 @@ pub fn validate_config(config: &Config) -> ValidationResult {
     validate_proxy_hosts(config, &mut errors);
     validate_proxy_has_a_routable_host(config, &mut errors);
     validate_tcp_targets(config, &mut errors);
+    validate_host_network_ports(config, &mut errors);
 
     if let Some(ssh) = &config.ssh {
         let user_can_come_from_config = !matches!(ssh.config, SshConfigFiles::Enabled(false));
@@ -571,6 +581,64 @@ fn validate_tcp_target(
         return;
     }
     seen_listen_ports.insert(listen_port, service_name.to_string());
+}
+
+/// `network_mode: host` shares the host's own network stack, so `ports:` exists only as metadata
+/// (what the service listens on), never as a `-p` mapping: at most one entry, a bare
+/// container-side port number, never a `host:container` mapping or a `/udp` suffix. Two
+/// `host`-mode services whose `servers:` sets overlap must not declare the same port, since both
+/// containers would try to bind it on the same machine. Project-scoped only, the same
+/// cross-project blind spot `validate_tcp_targets` already discloses for its own port space: a
+/// different project's `host`-mode service on a shared machine can still collide, surfacing at
+/// container start instead.
+fn validate_host_network_ports(config: &Config, errors: &mut Vec<ValidationError>) {
+    let mut seen_ports: Vec<(u16, &str, &Vec<String>)> = Vec::new();
+    for (name, service) in &config.services {
+        if service.network_mode != "host" {
+            continue;
+        }
+        if service.ports.len() > 1 {
+            errors.push(ValidationError {
+                path: format!("services.{name}.ports"),
+                message: format!(
+                    "Service '{name}' uses network_mode: host and can declare at most one port (the port it listens on); found {}",
+                    service.ports.len()
+                ),
+                code: "HOST_NETWORK_TOO_MANY_PORTS",
+            });
+            continue;
+        }
+        let Some(raw_port) = service.ports.first() else {
+            continue;
+        };
+        let Ok(port) = raw_port.parse::<u16>() else {
+            errors.push(ValidationError {
+                path: format!("services.{name}.ports"),
+                message: format!(
+                    "Service '{name}' uses network_mode: host; 'ports' entry '{raw_port}' must be a bare container port number, not a host:container mapping or a /udp suffix -- the app must already bind the port it wants."
+                ),
+                code: "HOST_NETWORK_INVALID_PORT",
+            });
+            continue;
+        };
+        for (existing_port, existing_service, existing_servers) in &seen_ports {
+            if *existing_port == port
+                && service
+                    .servers
+                    .iter()
+                    .any(|host| existing_servers.contains(host))
+            {
+                errors.push(ValidationError {
+                    path: format!("services.{name}.ports"),
+                    message: format!(
+                        "Service '{name}' uses network_mode: host on port {port}, already used by service '{existing_service}' on a shared server. Each host-mode service needs its own port on any server it shares."
+                    ),
+                    code: "HOST_NETWORK_PORT_CONFLICT",
+                });
+            }
+        }
+        seen_ports.push((port, name, &service.servers));
+    }
 }
 
 /// A cron container has no network namespace of its own to lease into once its service already

--- a/crates/jiji-config/tests/validation_test.rs
+++ b/crates/jiji-config/tests/validation_test.rs
@@ -309,6 +309,213 @@ services:
 }
 
 #[test]
+fn network_mode_none_is_rejected() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+services:
+  worker:
+    image: busybox
+    servers: [one]
+    network_mode: none
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == "NETWORK_MODE_NONE_UNSUPPORTED"));
+}
+
+#[test]
+fn network_mode_host_with_valid_single_port_validates_cleanly() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+services:
+  app:
+    image: nginx
+    servers: [one]
+    network_mode: host
+    ports: ["8080"]
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result
+        .errors
+        .iter()
+        .any(|error| error.code.starts_with("HOST_NETWORK")));
+}
+
+#[test]
+fn network_mode_host_rejects_more_than_one_port() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+services:
+  app:
+    image: nginx
+    servers: [one]
+    network_mode: host
+    ports: ["8080", "9090"]
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == "HOST_NETWORK_TOO_MANY_PORTS"));
+}
+
+#[test]
+fn network_mode_host_rejects_host_container_port_mapping() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+services:
+  app:
+    image: nginx
+    servers: [one]
+    network_mode: host
+    ports: ["8080:80"]
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == "HOST_NETWORK_INVALID_PORT"));
+}
+
+#[test]
+fn network_mode_host_rejects_udp_suffix() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+services:
+  app:
+    image: nginx
+    servers: [one]
+    network_mode: host
+    ports: ["8080/udp"]
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == "HOST_NETWORK_INVALID_PORT"));
+}
+
+#[test]
+fn network_mode_host_rejects_port_collision_on_shared_server() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+services:
+  app-a:
+    image: nginx
+    servers: [one]
+    network_mode: host
+    ports: ["8080"]
+  app-b:
+    image: nginx
+    servers: [one]
+    network_mode: host
+    ports: ["8080"]
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == "HOST_NETWORK_PORT_CONFLICT"));
+}
+
+#[test]
+fn network_mode_host_allows_same_port_on_disjoint_servers() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+  two: { host: 10.0.0.2 }
+services:
+  app-a:
+    image: nginx
+    servers: [one]
+    network_mode: host
+    ports: ["8080"]
+  app-b:
+    image: nginx
+    servers: [two]
+    network_mode: host
+    ports: ["8080"]
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result
+        .errors
+        .iter()
+        .any(|error| error.code.starts_with("HOST_NETWORK")));
+}
+
+#[test]
+fn network_mode_host_still_rejects_scale_and_proxy() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+services:
+  app:
+    image: nginx
+    servers: [one]
+    network_mode: host
+    ports: ["8080"]
+    replicas: 2
+    proxy:
+      port: 8080
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == "NON_BRIDGE_SCALE"));
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == "NON_BRIDGE_PROXY"));
+}
+
+#[test]
 fn ssh_section_with_zero_port_reports_invalid_port() {
     let raw = parse(
         r#"

--- a/crates/jiji-config/tests/validation_test.rs
+++ b/crates/jiji-config/tests/validation_test.rs
@@ -223,6 +223,34 @@ services:
 }
 
 #[test]
+fn network_mode_service_depending_on_a_host_mode_upstream_is_rejected() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+services:
+  gluetun:
+    image: gluetun
+    servers: [one]
+    network_mode: host
+    ports: ["8080"]
+  qbittorrent:
+    image: qbittorrent
+    servers: [one]
+    network_mode: service:gluetun
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == "NETWORK_MODE_SERVICE_HOST_UPSTREAM_UNSUPPORTED"));
+}
+
+#[test]
 fn network_mode_service_server_mismatch_is_rejected() {
     let raw = parse(
         r#"
@@ -416,6 +444,30 @@ services:
     servers: [one]
     network_mode: host
     ports: ["8080/udp"]
+"#,
+    );
+    let result = validate_yaml(&raw);
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == "HOST_NETWORK_INVALID_PORT"));
+}
+
+#[test]
+fn network_mode_host_rejects_port_zero() {
+    let raw = parse(
+        r#"
+project: demo
+builder: { engine: podman }
+servers:
+  one: { host: 10.0.0.1 }
+services:
+  app:
+    image: nginx
+    servers: [one]
+    network_mode: host
+    ports: ["0"]
 "#,
     );
     let result = validate_yaml(&raw);

--- a/crates/jiji-network/src/lib.rs
+++ b/crates/jiji-network/src/lib.rs
@@ -26,4 +26,4 @@ pub use proxy_script::{
     CONTAINER_NAME, INGRESS_TABLE, INTERNAL_HTTPS_PORT, INTERNAL_HTTP_PORT, PROXY_VERSION,
     RELAY_NAT_TABLE,
 };
-pub use service_runtime::NetworkedContainerRun;
+pub use service_runtime::{NetworkTarget, NetworkedContainerRun};

--- a/crates/jiji-network/src/service_runtime.rs
+++ b/crates/jiji-network/src/service_runtime.rs
@@ -124,28 +124,32 @@ impl NetworkedContainerRun {
                 args.push(self.bridge_name.clone());
                 args.push("--ip".to_string());
                 args.push(self.address.to_string());
-                args.push("--dns".to_string());
-                args.push(self.dns_address.to_string());
-                args.push("--dns-search".to_string());
-                args.push(jiji_core::DEFAULT_SERVICE_DOMAIN.to_string());
-                args.push("--dns-option".to_string());
-                args.push("ndots:1".to_string());
+                args.extend(self.dns_args());
             }
             NetworkTarget::Host => {
                 args.push("--network".to_string());
                 args.push("host".to_string());
-                args.push("--dns".to_string());
-                args.push(self.dns_address.to_string());
-                args.push("--dns-search".to_string());
-                args.push(jiji_core::DEFAULT_SERVICE_DOMAIN.to_string());
-                args.push("--dns-option".to_string());
-                args.push("ndots:1".to_string());
+                args.extend(self.dns_args());
             }
         }
         args.extend(self.extra_args.clone());
         args.push(self.image.clone());
         args.extend(self.command.clone());
         args
+    }
+
+    /// `--dns`/`--dns-search`/`--dns-option` flags shared by `Bridge` and `Host`: both need
+    /// `.jiji` resolution, unlike `SharedContainer`, which inherits its resolver config from
+    /// whatever container it joins.
+    fn dns_args(&self) -> Vec<String> {
+        vec![
+            "--dns".to_string(),
+            self.dns_address.to_string(),
+            "--dns-search".to_string(),
+            jiji_core::DEFAULT_SERVICE_DOMAIN.to_string(),
+            "--dns-option".to_string(),
+            "ndots:1".to_string(),
+        ]
     }
 
     pub fn shell_command(&self) -> String {

--- a/crates/jiji-network/src/service_runtime.rs
+++ b/crates/jiji-network/src/service_runtime.rs
@@ -2,6 +2,24 @@ use crate::ServerPlan;
 use jiji_config::ContainerEngine;
 use std::net::Ipv4Addr;
 
+/// Which network namespace a container attaches to. Replaces a bare `Option<String>` "shared
+/// with" field because there are now three genuinely different shapes to render, not two.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetworkTarget {
+    /// The project bridge, with a leased `--ip` and `--dns*` flags (`network_mode: bridge`, the
+    /// default).
+    Bridge,
+    /// A `network_mode: service:<other>` dependent: the upstream service's current container
+    /// name, joined via `--network container:<name>`. `args()` omits `--ip`/`--dns`/
+    /// `--dns-search`/`--dns-option` entirely, since a namespace-sharing container has no address
+    /// or DNS configuration of its own -- it inherits the upstream's.
+    SharedContainer(String),
+    /// `network_mode: host`: shares the host's network namespace via `--network host`. Unlike
+    /// `SharedContainer`, this still renders `--dns*` flags (pointed at the server's DNS agent),
+    /// since a host-networked container inherits nothing else's resolver configuration.
+    Host,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NetworkedContainerRun {
     pub engine: ContainerEngine,
@@ -11,11 +29,7 @@ pub struct NetworkedContainerRun {
     pub dns_address: Ipv4Addr,
     pub bridge_name: String,
     pub bridge_interface: String,
-    /// Set only for a `network_mode: service:<other>` dependent: the upstream service's current
-    /// container name to join via `--network container:<name>`. When set, `args()` omits
-    /// `--ip`/`--dns`/`--dns-search`/`--dns-option` entirely, since a namespace-sharing container
-    /// has no address or DNS configuration of its own -- it inherits the upstream's.
-    pub shared_with_container: Option<String>,
+    pub network_target: NetworkTarget,
     pub extra_args: Vec<String>,
     pub command: Vec<String>,
 }
@@ -36,7 +50,7 @@ impl NetworkedContainerRun {
             dns_address: server.dns_address,
             bridge_name: server.bridge_name.clone(),
             bridge_interface: server.bridge_interface.clone(),
-            shared_with_container: None,
+            network_target: NetworkTarget::Bridge,
             extra_args: Vec::new(),
             command: Vec::new(),
         }
@@ -45,7 +59,7 @@ impl NetworkedContainerRun {
     /// A `network_mode: service:<other>` dependent: shares `target_container`'s network
     /// namespace instead of getting its own dynamically-leased bridge address. `address` is the
     /// upstream's current address (kept for observability/health-check use, but never rendered
-    /// into the run command -- see `shared_with_container` above).
+    /// into the run command -- see `NetworkTarget::SharedContainer` above).
     pub fn shared(
         engine: ContainerEngine,
         container_name: impl Into<String>,
@@ -62,7 +76,32 @@ impl NetworkedContainerRun {
             dns_address: server.dns_address,
             bridge_name: server.bridge_name.clone(),
             bridge_interface: server.bridge_interface.clone(),
-            shared_with_container: Some(target_container.into()),
+            network_target: NetworkTarget::SharedContainer(target_container.into()),
+            extra_args: Vec::new(),
+            command: Vec::new(),
+        }
+    }
+
+    /// A `network_mode: host` service: shares the host's own network namespace. `address` is the
+    /// server's `management_address` (the WireGuard mesh address), kept for the `jiji.lease`
+    /// label/catalog/health-check role the leased address plays for `dynamic()`, since a
+    /// host-networked container has no address lease of its own.
+    pub fn host(
+        engine: ContainerEngine,
+        container_name: impl Into<String>,
+        image: impl Into<String>,
+        address: Ipv4Addr,
+        server: &ServerPlan,
+    ) -> Self {
+        Self {
+            engine,
+            container_name: container_name.into(),
+            image: image.into(),
+            address,
+            dns_address: server.dns_address,
+            bridge_name: server.bridge_name.clone(),
+            bridge_interface: server.bridge_interface.clone(),
+            network_target: NetworkTarget::Host,
             extra_args: Vec::new(),
             command: Vec::new(),
         }
@@ -75,16 +114,26 @@ impl NetworkedContainerRun {
             "--name".to_string(),
             self.container_name.clone(),
         ];
-        match &self.shared_with_container {
-            Some(target) => {
+        match &self.network_target {
+            NetworkTarget::SharedContainer(target) => {
                 args.push("--network".to_string());
                 args.push(format!("container:{target}"));
             }
-            None => {
+            NetworkTarget::Bridge => {
                 args.push("--network".to_string());
                 args.push(self.bridge_name.clone());
                 args.push("--ip".to_string());
                 args.push(self.address.to_string());
+                args.push("--dns".to_string());
+                args.push(self.dns_address.to_string());
+                args.push("--dns-search".to_string());
+                args.push(jiji_core::DEFAULT_SERVICE_DOMAIN.to_string());
+                args.push("--dns-option".to_string());
+                args.push("ndots:1".to_string());
+            }
+            NetworkTarget::Host => {
+                args.push("--network".to_string());
+                args.push("host".to_string());
                 args.push("--dns".to_string());
                 args.push(self.dns_address.to_string());
                 args.push("--dns-search".to_string());
@@ -167,6 +216,29 @@ mod tests {
         assert!(command.contains("--network container:demo-gluetun-def"));
         assert!(!command.contains("--ip"));
         assert!(!command.contains("--dns"));
+        assert!(!command.contains(&server.bridge_name));
+    }
+
+    #[test]
+    fn host_run_uses_network_host_and_keeps_dns() {
+        let config: jiji_config::Config = serde_yaml::from_str(
+            "project: demo\nbuilder: { engine: docker }\nservers:\n  app: { host: 203.0.113.10 }\nservices:\n  web: { image: nginx, servers: [app] }\n",
+        )
+        .unwrap();
+        let plan = NetworkPlanner::new().plan(&config).unwrap();
+        let server = &plan.servers["app"];
+        let run = NetworkedContainerRun::host(
+            ContainerEngine::Docker,
+            "demo-web-abc",
+            "nginx:latest",
+            server.management_address,
+            server,
+        );
+        let command = run.shell_command();
+        assert!(command.contains("--name demo-web-abc"));
+        assert!(command.contains("--network host"));
+        assert!(command.contains(&format!("--dns {}", server.dns_address)));
+        assert!(!command.contains("--ip"));
         assert!(!command.contains(&server.bridge_name));
     }
 }

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -260,11 +260,37 @@ deferred until the dependent wave finishes.
 Namespace-sharing updates are not zero-downtime. There is a real interval
 between removal of the old upstream and attachment of the new dependent.
 
+### Host networking (`network_mode: host`)
+
+A service can instead share the host's own network namespace via
+`network_mode: host`. Unlike `service:<upstream>` sharing, it still goes
+through the full candidate/active/draining/tombstone catalog lifecycle and a
+container-readiness health check, exactly like a bridge-networked service
+does; it just never leases an address from the agent. The catalog record's
+address is the server's own management (WireGuard mesh) address, since the
+container shares that interface directly. `ports:` accepts at most one bare
+container-side port number as routing metadata only, never rendered as
+`-p`: combining `-p` with `--network host` is a discarded, warning-spamming
+no-op on current Docker/Podman and a hard error on some older Podman
+releases. Two `host`-mode services whose `servers` overlap cannot declare
+the same port; the check is project-scoped, so a different project's
+`host`-mode service on a shared machine can still collide, surfacing as a
+failed container start rather than a validation error. `proxy:` and
+`replicas > 1` are rejected by the same generic non-bridge checks that
+already apply to `service:<name>` sharing.
+
+`network_mode: none` is rejected by validation outright: every service
+needs a reachable address for DNS and health checks, the catalog's address
+field is not optional, and the one legitimate use of `none` (an isolated
+one-off with no network needs) is already served by `crons:`.
+
 Sources:
 
 - `crates/jiji-config/src/validation.rs`
 - `crates/jiji-cli/src/cascade.rs`
 - `crates/jiji-cli/src/deploy_transaction.rs`
+- `crates/jiji-network/src/service_runtime.rs`
+- `crates/jiji-cli/src/container_runtime.rs`
 
 ## Scheduled Jobs
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -288,16 +288,22 @@ silently gain host networking through the shared namespace without ever
 declaring `network_mode: host` itself, so validation rejects it the same
 way it rejects a chained `service:<name>` dependency.
 
-Known gap: `host` mode's `jiji.lease` label carries `management_address`
-for observability, reusing the convention `service:<upstream>` sharing
-already established for the upstream's address. Agent-side discovery does
-not distinguish this from a genuine per-deployment bridge lease, so it
-tries to record that label's address as a real lease keyed by
-`deployment_id`. For `host` mode this leaves a permanently-orphaned
-`address_leases` row after every redeploy, since cleanup only runs from the
-bridge `AllocateAddress` path. Pre-existing for `service:<name>` sharing;
-`host` mode makes it worse because a `host`-only project never calls that
-path at all.
+`host` mode's `jiji.lease` label carries `management_address` for
+observability, reusing the convention `service:<upstream>` sharing already
+established for the upstream's address; neither ever holds a real
+per-deployment bridge lease. A second label, `jiji.lease-owned`, tells
+agent-side discovery which is which (`true` only for a genuine dynamic
+bridge lease, rendered by `container_runtime::render_dynamic_labels`):
+`recover_labeled_leases` (`jiji-agent/src/discovery.rs`) skips recovery
+outright when it reads `jiji.lease-owned=false`, rather than durably
+recording an observability-only address as a real claim keyed by
+`deployment_id` -- a row nothing would otherwise ever clean up for a
+`host`-only project, since expiry only runs from the bridge
+`AllocateAddress` path. A container with no `jiji.lease-owned` label at all
+(from a `jiji-cli` build predating this label) still gets the previous
+unconditional recovery attempt, so an in-place agent upgrade never
+regresses recovery for an already-running bridge deployment ahead of its
+next redeploy.
 
 Sources:
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -282,7 +282,22 @@ already apply to `service:<name>` sharing.
 `network_mode: none` is rejected by validation outright: every service
 needs a reachable address for DNS and health checks, the catalog's address
 field is not optional, and the one legitimate use of `none` (an isolated
-one-off with no network needs) is already served by `crons:`.
+one-off with no network needs) is already served by `crons:`. A
+`service:<name>` dependent cannot target a `host`-mode upstream: it would
+silently gain host networking through the shared namespace without ever
+declaring `network_mode: host` itself, so validation rejects it the same
+way it rejects a chained `service:<name>` dependency.
+
+Known gap: `host` mode's `jiji.lease` label carries `management_address`
+for observability, reusing the convention `service:<upstream>` sharing
+already established for the upstream's address. Agent-side discovery does
+not distinguish this from a genuine per-deployment bridge lease, so it
+tries to record that label's address as a real lease keyed by
+`deployment_id`. For `host` mode this leaves a permanently-orphaned
+`address_leases` row after every redeploy, since cleanup only runs from the
+bridge `AllocateAddress` path. Pre-existing for `service:<name>` sharing;
+`host` mode makes it worse because a `host`-only project never calls that
+path at all.
 
 Sources:
 
@@ -291,6 +306,7 @@ Sources:
 - `crates/jiji-cli/src/deploy_transaction.rs`
 - `crates/jiji-network/src/service_runtime.rs`
 - `crates/jiji-cli/src/container_runtime.rs`
+- `crates/jiji-agent/src/discovery.rs`
 
 ## Scheduled Jobs
 


### PR DESCRIPTION
Implements `network_mode: host` and rejects `network_mode: none`.

Previously `crates/jiji-config/src/jiji.yml` documented `host`/`none` but no runtime code read them, so both silently kept bridge networking. This fills the gap.

### What changed

**`jiji-network` (`NetworkTarget::Host`, `service_runtime.rs` / `lib.rs`):**
New `NetworkTarget::Host` variant. `NetworkedContainerRun::host` renders `--network host` plus `--dns*` flags (still needed for `.jiji` resolution, unlike `service:<name>` sharing) and never `--ip` or `-p`.

**Deploy (`crates/jiji-cli/src/deploy_transaction.rs` / `container_runtime.rs` / `container_ops.rs`):**
New `deploy_host_mode` transaction. Skips `AllocateAddress` RPC and uses `ServerPlan.management_address` (WireGuard mesh address) everywhere the bridge path uses a leased address: catalog commit, `jiji.lease` label. Otherwise identical lifecycle: candidate commit, `create_and_start`, container-readiness health check, commit to `Active`/`Healthy`, then drain/tombstone previous replica. No proxy route activation (validation already rejects `proxy:` for non-bridge modes). `build_host_run` omits `-p` intentionally (`-p` with `--network host` is a discarded warning on current Docker/Podman and a hard error on some older Podman). `container_ops::create_and_start` skips `reconcile_podman_dns_address` for non-bridge targets. Previous-container lease release stays unconditional and no-ops on the agent when nothing was leased.

**`jiji-agent` (`crates/jiji-agent/src/cron_exec.rs`):**
Adapted to `NetworkTarget::Bridge` (cron jobs are already rejected by validation for `service:<name>` and host-mode has the same constraint).

**Validation (`crates/jiji-config/src/validation.rs` / `jiji.yml`):**
- `network_mode: none` rejected outright (every service needs a reachable address for DNS and health checks; `none` isolation is already covered by `crons:`).
- `network_mode: host` allows at most one bare container-side `ports:` entry as routing/uniqueness metadata only, rejects per-server port collisions across host-mode replicas, and inherits the existing generic non-bridge rejects for `proxy:` and `replicas > 1`.

### Tests
- `crates/jiji-cli/tests/network_mode_host_test.rs` (new, mock-SSH harness capturing `jiji-agent` request stdin to assert catalog-commit address and `docker run` rendering).
- `crates/jiji-config/tests/validation_test.rs` updated for host/none coverage.
- `crates/jiji-cli/src/container_runtime.rs` unit test `build_host_run_uses_network_host_omits_ports_and_labels_management_address`.

### Docs
`AGENTS.md` (Host Networking section), `docs/architecture-notes.md`, and `crates/jiji-config/src/jiji.yml` reference updated. Removes stale TODO that listed `host`/`none` as unimplemented.

No breaking config change beyond the new `none` rejection; existing `bridge` and `service:<name>` behavior unchanged.
